### PR TITLE
fix: events visibility for weeks/days

### DIFF
--- a/src/components/eventCalendar/EventCalendar.tsx
+++ b/src/components/eventCalendar/EventCalendar.tsx
@@ -50,6 +50,10 @@ export function EventCalendar(props:Props) {
   endRange.setFullYear(endRange.getFullYear() + 1);
 
   props.events.forEach((event) => {
+    const ev = {...event};
+    // TODO: check for TimeZone.
+    ev.start = new Date(ev.start);
+    ev.end = new Date(ev.end);
     if (event.recurrenceRule) {
       const dates = EventHelper.getRange(event, startRange, endRange);
       dates.forEach((date) => {
@@ -61,7 +65,7 @@ export function EventCalendar(props:Props) {
       });
       EventHelper.removeExcludeDates(expandedEvents);
     }
-    else expandedEvents.push(event);
+    else expandedEvents.push(ev);
   });
 
   return (

--- a/src/components/eventCalendar/EventCalendar.tsx
+++ b/src/components/eventCalendar/EventCalendar.tsx
@@ -51,7 +51,6 @@ export function EventCalendar(props:Props) {
 
   props.events.forEach((event) => {
     const ev = {...event};
-    // TODO: check for TimeZone.
     ev.start = new Date(ev.start);
     ev.end = new Date(ev.end);
     if (event.recurrenceRule) {


### PR DESCRIPTION
In the group calendar, recurring events are visible in weeks/days mode, but single events are not visible. It's just because react-big-calendar expects dates to be in the Javascript Date object.