### PR TITLE
fix: display date format

### DIFF
--- a/src/components/eventCalendar/DisplayEventModal.tsx
+++ b/src/components/eventCalendar/DisplayEventModal.tsx
@@ -25,8 +25,12 @@ export function DisplayEventModal(props: Props) {
       else result = `${prettyStartDate} - ${prettyEndDate}`;
     } else {
       const prettyStart = DateHelper.prettyDateTime(props.event.start)
-      const prettyEnd = DateHelper.prettyTime(props.event.end)
-      result = `${prettyStart} - ${prettyEnd}`;
+      const prettyEnd = DateHelper.prettyDateTime(props.event.end)
+      const prettyEndTime = DateHelper.prettyTime(props.event.end);
+      const startDate = DateHelper.prettyDate(new Date(prettyStart))
+      const endDate = DateHelper.prettyDate(new Date(prettyEnd))
+      if (startDate === endDate) result = `${prettyStart} - ${prettyEndTime}`
+      else result = `${prettyStart} - ${prettyEnd}`;
     }
     return result;
   }


### PR DESCRIPTION
Problem: when we click on a group event, it displays the event's title, date&time, etc. when you see the date&time, if it's a one-day event it shows - EX: May 25, 2023 5:30 PM - 6:30 PM - and when it's a three-day event it still shows the date in the same format, so there's no way to find out on which date the event ends.

Solution: Changed the date format for the display, so if it's a three-day event, it'll show the date like this - May 4, 2023 11:00 PM - May 8, 2023 12:00 AM.