### PR TITLE
fix: event delete

### DIFF
--- a/src/components/admin/calendar/DisplayCalendarEventModal.tsx
+++ b/src/components/admin/calendar/DisplayCalendarEventModal.tsx
@@ -1,12 +1,10 @@
 import { Dialog, DialogContent, DialogActions, Typography, Box, Button } from "@mui/material";
-import { DateHelper, EventInterface, CuratedEventInterface, ApiHelper } from "@/helpers";
-
-interface EventBody extends EventInterface, CuratedEventInterface {}
+import { DateHelper, CuratedEventWithEventInterface, ApiHelper } from "@/helpers";
 
 interface Props {
-  event: EventBody;
+  event: CuratedEventWithEventInterface;
   curatedCalendarId?: string;
-  handleDone?: () => void;
+  onDone?: () => void;
 }
 
 export function DisplayCalendarEventModal(props: Props) {
@@ -32,13 +30,13 @@ export function DisplayCalendarEventModal(props: Props) {
   const handleDelete = () => {
     if (confirm("Are you sure you wish to delete this event?")) {
       ApiHelper.delete("/curatedEvents/calendar/" + props.curatedCalendarId + "/event/" + props.event.id, "ContentApi").then(() => {
-        props.handleDone();
+        props.onDone();
       })
     }
   }
 
   return (
-    <Dialog open={true} onClose={props.handleDone} fullWidth scroll="body">
+    <Dialog open={true} onClose={props.onDone} fullWidth scroll="body">
       <DialogContent>
         <Box borderLeft={5} borderRadius={1} borderColor="#1976d2" padding={2} paddingBottom={0}>
           <Typography variant="h5" fontWeight={550} marginBottom={1}>{props.event.title}</Typography>
@@ -47,7 +45,7 @@ export function DisplayCalendarEventModal(props: Props) {
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button variant="text" onClick={props.handleDone}>Cancel</Button>
+        <Button variant="text" onClick={props.onDone}>Cancel</Button>
         {props.event.eventId && <Button variant="contained" onClick={handleDelete}>Delete</Button>}
       </DialogActions>
     </Dialog>

--- a/src/components/admin/calendar/DisplayCalendarEventModal.tsx
+++ b/src/components/admin/calendar/DisplayCalendarEventModal.tsx
@@ -1,8 +1,10 @@
 import { Dialog, DialogContent, DialogActions, Typography, Box, Button } from "@mui/material";
-import { DateHelper, EventInterface, ApiHelper } from "@/helpers";
+import { DateHelper, EventInterface, CuratedEventInterface, ApiHelper } from "@/helpers";
+
+interface EventBody extends EventInterface, CuratedEventInterface {}
 
 interface Props {
-  event: EventInterface;
+  event: EventBody;
   curatedCalendarId?: string;
   handleDone?: () => void;
 }
@@ -46,7 +48,7 @@ export function DisplayCalendarEventModal(props: Props) {
       </DialogContent>
       <DialogActions>
         <Button variant="text" onClick={props.handleDone}>Cancel</Button>
-        <Button variant="contained" onClick={handleDelete}>Delete</Button>
+        {props.event.eventId && <Button variant="contained" onClick={handleDelete}>Delete</Button>}
       </DialogActions>
     </Dialog>
   );

--- a/src/pages/[sdSlug]/admin/calendars/[id].tsx
+++ b/src/pages/[sdSlug]/admin/calendars/[id].tsx
@@ -188,7 +188,7 @@ export default function CalendarPage(props: WrapperPageProps) {
           </DisplayBox>
         </Grid>
       </Grid>
-      {displayCalendarEvent && <DisplayCalendarEventModal event={displayCalendarEvent} curatedCalendarId={curatedCalendarId as string} handleDone={() => { setDisplayCalendarEvent(null); loadData(); }} />}
+      {displayCalendarEvent && <DisplayCalendarEventModal event={displayCalendarEvent} curatedCalendarId={curatedCalendarId as string} onDone={() => { setDisplayCalendarEvent(null); loadData(); }} />}
       <Dialog open={open} onClose={handleDone} fullWidth scroll="body" fullScreen={fullScreen}>
         <DialogTitle>Add a Group</DialogTitle>
         <DialogContent>


### PR DESCRIPTION
In Display Modal for Curated Calendar, if the whole group is added to the calendar then we don't want them to delete a single event from that group. So now the delete button will only be visible when single/specific events are added to the calendar.