### PR TITLE
fix: video timestamp for youtube_live

### DIFF
--- a/src/components/video/VideoContainer.tsx
+++ b/src/components/video/VideoContainer.tsx
@@ -31,7 +31,7 @@ export const VideoContainer: React.FC<Props> = (props) => {
         if (cs?.sermon?.videoType === "youtube") videoUrl += "&start=" + seconds.toString();
         if (cs?.sermon?.videoType === "vimeo") videoUrl += "#t=" + seconds.toString() + "s";
       } else {
-        if (cs?.sermon?.videoType === "youtube") videoUrl += "&start=0";
+        if (cs?.sermon?.videoType === "youtube") videoUrl += "&start=1";
         if (cs?.sermon?.videoType === "vimeo") videoUrl += "#t=0m0s";
       }
     }


### PR DESCRIPTION
Problem: If you've previously watched a video on youtube and if you create a live service of that video then it'll start from where you left off, instead from the beginning.

How to check: watch any video on youtube, then create a live service of that video on b1.