### PR TITLE
Check In Photo Fix

### DIFF
--- a/src/components/checkin/Household.tsx
+++ b/src/components/checkin/Household.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useState, useEffect } from "react";
 import { Button, Icon, Grid, Box } from "@mui/material";
-import { CheckinHelper, EnvironmentHelper } from "@/helpers";
+import { CheckinHelper } from "@/helpers";
 import { Groups } from "./Groups";
 import { VisitInterface, GroupInterface, PersonInterface, ArrayHelper, ServiceTimeInterface, VisitSessionInterface, ApiHelper, Loading, PersonHelper } from "@churchapps/apphelper";
 

--- a/src/components/checkin/Household.tsx
+++ b/src/components/checkin/Household.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { Button, Icon, Grid, Box } from "@mui/material";
 import { CheckinHelper, EnvironmentHelper } from "@/helpers";
 import { Groups } from "./Groups";
-import { VisitInterface, GroupInterface, PersonInterface, ArrayHelper, ServiceTimeInterface, VisitSessionInterface, ApiHelper, Loading } from "@churchapps/apphelper";
+import { VisitInterface, GroupInterface, PersonInterface, ArrayHelper, ServiceTimeInterface, VisitSessionInterface, ApiHelper, Loading, PersonHelper } from "@churchapps/apphelper";
 
 interface Props {
   completeHandler: () => void;
@@ -132,7 +132,7 @@ export function Household({ completeHandler = () => { } }: Props) {
               {arrow}
             </Grid>
             <Grid item xs={2}>
-              <img src={EnvironmentHelper.Common.ContentRoot + member.photo} alt="avatar" />
+              <img src={PersonHelper.getPhotoUrl(member)} alt="avatar" />
             </Grid>
             <Grid item xs={9}>
               {member.name.display}

--- a/src/components/member/directory/Household.tsx
+++ b/src/components/member/directory/Household.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { EnvironmentHelper } from "../../../helpers"
 import { PersonInterface, Loading, ApiHelper, DisplayBox, PersonHelper } from "@churchapps/apphelper"
 import { Grid } from "@mui/material";
 

--- a/src/components/member/directory/Household.tsx
+++ b/src/components/member/directory/Household.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { EnvironmentHelper } from "../../../helpers"
-import { PersonInterface, Loading, ApiHelper, DisplayBox } from "@churchapps/apphelper"
+import { PersonInterface, Loading, ApiHelper, DisplayBox, PersonHelper } from "@churchapps/apphelper"
 import { Grid } from "@mui/material";
 
 interface Props { person: PersonInterface, selectedHandler: (personId: string) => void }
@@ -13,7 +13,7 @@ export const Household: React.FC<Props> = (props) => {
     const m = member;
     return (<a href="about:blank" className="householdMember" onClick={(e) => { e.preventDefault(); props.selectedHandler(m.id) }}>
       <Grid container spacing={3}>
-        <Grid item xs={2}><img src={EnvironmentHelper.Common.ContentRoot + member?.photo} alt="avatar" /></Grid>
+        <Grid item xs={2}><img src={PersonHelper.getPhotoUrl(member)} alt="avatar" /></Grid>
         <Grid item xs={10}>
           {member?.name?.display}
           <div><span>{member?.householdRole}</span></div>


### PR DESCRIPTION
Fixed the "no photo url" to show default sample image instead of a broken link. Fixed it in two places- the first one (Household.tsx checkin) worked fine so I assume the other (Household.tsx directory) also needed that updated, feel free to undo if necessary.