### PR TITLE
fix: switch from package to basic html for carousel

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "react-dom": "^19.1.0",
     "react-helmet": "^6.1.0",
     "react-image-file-resizer": "^0.4.8",
-    "react-material-ui-carousel": "^3.4.2",
     "react-router-dom": "^7.6.3",
     "react-youtube": "^10.1.0",
     "rrule": "^2.8.1",

--- a/src/components/elementTypes/CarouselElement.tsx
+++ b/src/components/elementTypes/CarouselElement.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import Carousel from "react-material-ui-carousel";
+import React, { useState, useEffect, useRef } from "react";
 import { ElementInterface, SectionInterface } from "@/helpers";
 import { ApiHelper } from "@churchapps/apphelper/dist/helpers/ApiHelper";
 import { DroppableArea } from "../admin/DroppableArea";
@@ -14,11 +13,22 @@ interface Props {
 }
 
 export const CarouselElement = ({ element, churchSettings, textColor, onEdit, onMove }: Props) => {
+  const [current, setCurrent] = useState(0);
 
-  const getClassName = () => {
-    if (onEdit) return "columnWrapper";
-    else return "";
-  };
+  const interval = (parseInt(element.answers.interval) || 4) * 1000;
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const fade = element.answers.animationOptions === "fade";
+  const autoPlay = element.answers.autoplay === "true" && !onEdit;
+  const length = element.elements?.length || 0;
+
+  const goTo = (idx: number) => setCurrent(idx);
+  const prev = () => setCurrent((prev) => (prev - 1 + length) % length);
+  const next = () => setCurrent((prev) => (prev + 1) % length);
+
+  // const getClassName = () => {
+  //   if (onEdit) return "columnWrapper";
+  //   else return "";
+  // };
 
   const handleDrop = (data: any, sort: number, column: ElementInterface) => {
     if (data.data) {
@@ -50,36 +60,153 @@ export const CarouselElement = ({ element, churchSettings, textColor, onEdit, on
     return result;
   };
 
-  const getColumns = () => {
-    const emptyStyle = { minHeight: 100, border: "1px solid #999" };
-    const result: React.ReactElement[] = [];
-    element.elements?.forEach((c) => {
-      //{onEdit && <div style={{ height: "31px", paddingTop: "31px", paddingBottom: "31px" }}>{getAddElement(c, c?.elements?.[c?.elements.length - 1]?.sort + 0.1, "Drop at the bottom of slide")}</div>}
-      result.push(
-        <div key={c.id} className={getClassName()} style={c?.elements?.length > 0 || !onEdit ? {} : emptyStyle}>
-          <div style={{ minHeight: "inherit" }}>
-            {getElements(c, c.elements)}
-          </div>
-          {onEdit && <div style={{ height: "31px"}}></div>}
+  // const getColumns = () => {
+  //   const emptyStyle = { minHeight: 100, border: "1px solid #999" };
+  //   const result: React.ReactElement[] = [];
+  //   element.elements?.forEach((c) => {
+  //     result.push(
+  //       <div
+  //         key={c.id}
+  //         className={getClassName()}
+  //         style={
+  //           c?.elements?.length > 0 || !onEdit
+  //             ? { height: "100%" }
+  //             : { ...emptyStyle, height: "100%" }
+  //         }
+  //       >
+  //         <div style={{ minHeight: "inherit", height: "100%" }}>
+  //           {getElements(c, c.elements)}
+  //         </div>
+  //         {onEdit && <div style={{ height: "31px" }}></div>}
+  //       </div>
+  //     );
+  //   });
+  //   return result;
+  // };
+
+  const getFadeSlides = () => (
+    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      {element.elements?.map((c, idx) => (
+        <div
+          key={c.id}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            opacity: idx === current ? 1 : 0,
+            transition: "opacity 0.5s",
+            zIndex: idx === current ? 1 : 0,
+          }}
+        >
+          <div style={{ height: "100%" }}>{getElements(c, c.elements)}</div>
         </div>
-      );
-    });
-    return result;
-  };
+      ))}
+    </div>
+  );
+
+  const getSlideAnimation = () => (
+    <div
+      style={{
+        display: "flex",
+        transition: "transform 0.5s",
+        transform: `translateX(-${current * 100}%)`,
+        height: "100%",
+        // width: `${length * 100}%`,
+      }}
+    >
+      {element.elements?.map((c, idx) => (
+        <div key={c.id} style={{ flex: "0 0 100%", height: "100%" }}>
+          <div style={{ height: "100%" }}>{getElements(c, c.elements)}</div>
+        </div>
+      ))}
+    </div>
+  );
+
+  const getNavigation = () => (
+    <>
+      <div
+        onClick={prev}
+        style={{
+          position: "absolute",
+          left: 5,
+          top: "50%",
+          transform: "translateY(-50%)",
+          zIndex: 2,
+          backgroundColor: "#494949",
+          borderRadius: 20,
+          cursor: "pointer",
+        }}
+      >
+        <div style={{ padding: "8px 16px" }}>{"<"}</div>
+      </div>
+      <div
+        onClick={next}
+        style={{
+          position: "absolute",
+          right: 5,
+          top: "50%",
+          transform: "translateY(-50%)",
+          zIndex: 2,
+          backgroundColor: "#494949",
+          borderRadius: 20,
+          cursor: "pointer",
+        }}
+      >
+        <div style={{ padding: "8px 16px" }}>{">"}</div>
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          bottom: 10,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 2,
+        }}
+      >
+        {element.elements?.map((_, idx) => (
+          <button
+            key={idx}
+            onClick={() => goTo(idx)}
+            style={{
+              margin: 2,
+              width: 12,
+              height: 12,
+              borderRadius: "50%",
+              background: idx === current ? "#333" : "#ccc",
+              border: "none",
+              cursor: "pointer",
+            }}
+          />
+        ))}
+      </div>
+    </>
+  );
+
+  useEffect(() => {
+    if (!autoPlay || length <= 1) return;
+    timerRef.current = setInterval(() => {
+      setCurrent((prev) => (prev + 1) % length);
+    }, interval);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [autoPlay, interval, length]);
 
   return (
-    <div id={"el-" + element.id}>
+    <div
+      id={"el-" + element.id}
+      style={{
+        margin: "0 auto",
+        height: parseInt(element.answers.height) || 250,
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
       {onEdit && <div style={{ height: 40 }}></div>}
-      <Carousel
-        interval={(parseInt(element.answers.interval) || 4) * 1000}
-        height={parseInt(element.answers.height) || 250}
-        animation={element.answers.animationOptions}
-        autoPlay={element.answers.autoplay === "true" && !onEdit ? true : false}
-        fullHeightHover={false}
-        navButtonsAlwaysVisible
-      >
-        {getColumns()}
-      </Carousel>
+      {fade ? getFadeSlides() : getSlideAnimation()}
+      {length > 1 && getNavigation()}
     </div>
   );
 };


### PR DESCRIPTION
Switched from "react-material-ui-carousel" package to raw html and CSS, cause the package doesn't support React-V19 and Mui-V7.

Plus, the 'npm i' wasn't working correctly because of that.