### PR TITLE
feat: migrate NewConversation to React Hook Form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "react-dom": "^19.2.1",
         "react-ga4": "^2.1.0",
         "react-helmet": "^6.1.0",
+        "react-hook-form": "^7.71.1",
         "react-image-file-resizer": "^0.4.8",
         "react-router-dom": "^7.6.3",
         "react-youtube": "^10.1.0",
@@ -10803,6 +10804,22 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.71.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
+      "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-i18next": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@churchapps/helpers": "^1.2.22",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@hookform/resolvers": "^5.2.2",
         "@mui/icons-material": "^7.3.6",
         "@mui/lab": "^7.0.0-beta.22",
         "@mui/material": "^7.3.6",
@@ -52,7 +53,8 @@
         "react-router-dom": "^7.6.3",
         "react-youtube": "^10.1.0",
         "rrule": "^2.8.1",
-        "webfontloader": "^1.6.28"
+        "webfontloader": "^1.6.28",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@playwright/test": "^1.53.0",
@@ -1203,6 +1205,18 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "supercluster": "^8.0.1"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4715,6 +4729,12 @@
         "webpack": ">=4.40.0"
       }
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@stripe/react-stripe-js": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.10.0.tgz",
@@ -5694,6 +5714,15 @@
       "integrity": "sha512-LnakJXzPvRgTjhjlLtrx3bc38+zsCvTUixGRhYL//4UneWdFRJ+az4MOTv7faFFLGlUFrQ3CcoMW3ah6I5BUdA==",
       "dependencies": {
         "zod": "4.1.12"
+      }
+    },
+    "node_modules/@youversion/platform-core/node_modules/zod": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@youversion/platform-react-hooks": {
@@ -13295,9 +13324,9 @@
       "license": "MIT"
     },
     "node_modules/zod": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
-      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-dom": "^19.2.1",
     "react-ga4": "^2.1.0",
     "react-helmet": "^6.1.0",
+    "react-hook-form": "^7.71.1",
     "react-image-file-resizer": "^0.4.8",
     "react-router-dom": "^7.6.3",
     "react-youtube": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@churchapps/helpers": "^1.2.22",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@hookform/resolvers": "^5.2.2",
     "@mui/icons-material": "^7.3.6",
     "@mui/lab": "^7.0.0-beta.22",
     "@mui/material": "^7.3.6",
@@ -63,7 +64,8 @@
     "react-router-dom": "^7.6.3",
     "react-youtube": "^10.1.0",
     "rrule": "^2.8.1",
-    "webfontloader": "^1.6.28"
+    "webfontloader": "^1.6.28",
+    "zod": "^4.3.6"
   },
   "overrides": {
     "react-is": "18.3.1"

--- a/src/components/member/directory/ProfileEdit.tsx
+++ b/src/components/member/directory/ProfileEdit.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import { useForm, Controller, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -112,13 +112,11 @@ export const ProfileEdit: React.FC<Props> = (props) => {
 
   const [showPhotoEditor, setShowPhotoEditor] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-  const originalPersonRef = useRef<PersonInterface | null>(null);
   const familyMembers = props.familyMembers || [];
 
   // Sync props to form - reset() updates values and clears dirty state
   useEffect(() => {
     if (props.person) {
-      originalPersonRef.current = JSON.parse(JSON.stringify(props.person));
       const { name, contactInfo, birthDate, photo } = props.person;
       reset({
         name: { ...PROFILE_DEFAULTS.name, ...name },

--- a/src/components/member/directory/ProfileEdit.tsx
+++ b/src/components/member/directory/ProfileEdit.tsx
@@ -1,24 +1,107 @@
+"use client";
+
+/**
+ * ProfileEdit Component - React Hook Form + Zod Example
+ *
+ * This file demonstrates migrating a complex form from manual useState
+ * handling to React Hook Form (RHF) with Zod validation.
+ *
+ * KEY CONCEPTS DEMONSTRATED:
+ * 1. Zod schema definition with nested objects
+ * 2. useForm hook with zodResolver for validation
+ * 3. Controller component for MUI TextField integration
+ * 4. Dirty field tracking (replaces manual change detection)
+ * 5. Form reset with new default values
+ * 6. Async form submission with isSubmitting state
+ * 7. Custom handling for non-standard inputs (photo editor)
+ */
+
 import React, { useState, useEffect, useRef } from "react";
-import { ApiHelper, ArrayHelper, DateHelper, ImageEditor, UserHelper } from "@churchapps/apphelper";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { ApiHelper, DateHelper, ImageEditor, UserHelper } from "@churchapps/apphelper";
 import type { GroupInterface, PersonInterface, TaskInterface } from "@churchapps/helpers";
 import { Button, Grid, TextField, Box, Typography, Alert } from "@mui/material";
 import { PersonHelper } from "../../../helpers";
 
-interface Props {
-  personId: string;
-  person: PersonInterface;
-  onSave?: () => void;
-  onCancel?: () => void;
-  familyMembers?: string[];
-  onFamilyMembersChange?: (members: string[]) => void;
-}
+// =============================================================================
+// ZOD SCHEMA DEFINITION
+// =============================================================================
+/**
+ * Zod schemas define the shape and validation rules for form data.
+ *
+ * Benefits over manual validation:
+ * - Type inference: TypeScript types are derived automatically
+ * - Composable: Schemas can be nested and reused
+ * - Declarative: Validation rules are defined once, not scattered in handlers
+ * - Rich error messages: Built-in and customizable error messages
+ */
 
-interface ProfileChange {
-  field: string;
-  label: string;
-  value: string;
-}
+/**
+ * Schema for the nested 'name' object.
+ * z.string() creates a string validator.
+ *
+ * Note: We use plain z.string() without .optional() here because:
+ * - Our defaultValues always provide strings
+ * - RHF expects the inferred type to match defaultValues exactly
+ * - Empty string "" is still valid (no .min(1) requirement)
+ */
+const nameSchema = z.object({
+  first: z.string(),
+  middle: z.string(),
+  last: z.string(),
+});
 
+/**
+ * Schema for the nested 'contactInfo' object.
+ *
+ * EMAIL VALIDATION PATTERN:
+ * - z.string().email() requires valid email format
+ * - .or(z.literal("")) creates a union type allowing empty string
+ * - This means: "must be valid email OR empty string" (optional but validated if provided)
+ */
+const contactInfoSchema = z.object({
+  email: z.string().email("Invalid email format").or(z.literal("")),
+  address1: z.string(),
+  address2: z.string(),
+  city: z.string(),
+  state: z.string(),
+  zip: z.string(),
+  homePhone: z.string(),
+  mobilePhone: z.string(),
+  workPhone: z.string(),
+});
+
+/**
+ * Main form schema combining all nested schemas.
+ * This creates a complete type-safe form structure.
+ *
+ * The inferred type will have all fields as required strings,
+ * matching our defaultValues structure exactly.
+ */
+const profileSchema = z.object({
+  name: nameSchema,
+  contactInfo: contactInfoSchema,
+  birthDate: z.string(),
+  // Photo is handled separately via ImageEditor, but tracked here for dirty state
+  photo: z.string(),
+});
+
+/**
+ * TypeScript type inferred from the Zod schema.
+ * z.infer<typeof schema> extracts the type, ensuring form data
+ * always matches the schema definition.
+ */
+type ProfileFormData = z.infer<typeof profileSchema>;
+
+// =============================================================================
+// FIELD DEFINITIONS (for change tracking display)
+// =============================================================================
+/**
+ * Maps form field paths to human-readable labels.
+ * Used to show users which fields they've modified.
+ */
 const fieldDefinitions = [
   { key: "name.first", label: "First Name" },
   { key: "name.middle", label: "Middle Name" },
@@ -36,89 +119,260 @@ const fieldDefinitions = [
   { key: "contactInfo.workPhone", label: "Work Phone" },
 ];
 
+// =============================================================================
+// COMPONENT PROPS
+// =============================================================================
+interface Props {
+  personId: string;
+  person: PersonInterface;
+  onSave?: () => void;
+  onCancel?: () => void;
+  familyMembers?: string[];
+  onFamilyMembersChange?: (members: string[]) => void;
+}
+
+interface ProfileChange {
+  field: string;
+  label: string;
+  value: string;
+}
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
 export const ProfileEdit: React.FC<Props> = (props) => {
-  const [person, setPerson] = useState<PersonInterface | null>(null);
-  const originalPersonRef = useRef<PersonInterface | null>(null);
-  const [modifiedFields, setModifiedFields] = useState<Set<string>>(new Set());
+  // ---------------------------------------------------------------------------
+  // REACT HOOK FORM SETUP
+  // ---------------------------------------------------------------------------
+  /**
+   * useForm is the main hook that manages all form state.
+   *
+   * Configuration options:
+   * - resolver: zodResolver(schema) connects Zod validation to RHF
+   * - defaultValues: Initial form values (important for dirty tracking)
+   * - mode: When validation runs ("onBlur", "onChange", "onSubmit", "all")
+   *
+   * Returns:
+   * - control: Object passed to Controller components
+   * - handleSubmit: Wrapper that validates before calling your submit function
+   * - formState: Contains errors, isDirty, dirtyFields, isSubmitting, etc.
+   * - reset: Function to reset form to new default values
+   * - setValue: Programmatically set a field value
+   * - watch: Subscribe to field value changes
+   */
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isDirty, dirtyFields, isSubmitting },
+    reset,
+    setValue,
+  } = useForm<ProfileFormData>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      name: { first: "", middle: "", last: "" },
+      contactInfo: {
+        email: "",
+        address1: "",
+        address2: "",
+        city: "",
+        state: "",
+        zip: "",
+        homePhone: "",
+        mobilePhone: "",
+        workPhone: "",
+      },
+      birthDate: "",
+      photo: "",
+    },
+    // "onBlur" validates when field loses focus - good balance of UX and feedback
+    mode: "onBlur",
+  });
+
+  // ---------------------------------------------------------------------------
+  // LOCAL STATE (non-form state)
+  // ---------------------------------------------------------------------------
+  /**
+   * Some state still lives outside RHF:
+   * - UI state (showPhotoEditor, submitted) - not form data
+   * - Original person ref - for building change list
+   *
+   * RHF handles: form values, validation errors, dirty tracking, submit state
+   */
   const [showPhotoEditor, setShowPhotoEditor] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const originalPersonRef = useRef<PersonInterface | null>(null);
 
   const familyMembers = props.familyMembers || [];
 
+  // ---------------------------------------------------------------------------
+  // SYNC PROPS TO FORM
+  // ---------------------------------------------------------------------------
+  /**
+   * When props.person changes, reset the form with new values.
+   *
+   * reset() does two important things:
+   * 1. Updates all form field values
+   * 2. Resets dirty state (isDirty becomes false, dirtyFields is cleared)
+   *
+   * This replaces the manual useState + useEffect pattern.
+   */
   useEffect(() => {
     if (props.person) {
-      setPerson({ ...props.person });
+      // Store original for change comparison
       originalPersonRef.current = JSON.parse(JSON.stringify(props.person));
+
+      // Reset form with person data, converting to our flat structure
+      reset({
+        name: {
+          first: props.person.name?.first || "",
+          middle: props.person.name?.middle || "",
+          last: props.person.name?.last || "",
+        },
+        contactInfo: {
+          email: props.person.contactInfo?.email || "",
+          address1: props.person.contactInfo?.address1 || "",
+          address2: props.person.contactInfo?.address2 || "",
+          city: props.person.contactInfo?.city || "",
+          state: props.person.contactInfo?.state || "",
+          zip: props.person.contactInfo?.zip || "",
+          homePhone: props.person.contactInfo?.homePhone || "",
+          mobilePhone: props.person.contactInfo?.mobilePhone || "",
+          workPhone: props.person.contactInfo?.workPhone || "",
+        },
+        birthDate: props.person.birthDate
+          ? DateHelper.formatHtml5Date(new Date(props.person.birthDate))
+          : "",
+        photo: props.person.photo || "",
+      });
     }
-  }, [props.person]);
+  }, [props.person, reset]);
 
-  const getFieldValue = (obj: PersonInterface, key: string): string => {
-    const parts = key.split(".");
-    let value: any = obj;
-    for (const part of parts) {
-      value = value?.[part];
-    }
-    if (key === "birthDate" && value) {
-      return DateHelper.formatHtml5Date(new Date(value));
-    }
-    return value || "";
-  };
-
-  const setFieldValue = (obj: PersonInterface, key: string, value: string): PersonInterface => {
-    const newObj = JSON.parse(JSON.stringify(obj));
-    const parts = key.split(".");
-    let target: any = newObj;
-    for (let i = 0; i < parts.length - 1; i++) {
-      if (!target[parts[i]]) target[parts[i]] = {};
-      target = target[parts[i]];
-    }
-    target[parts[parts.length - 1]] = value;
-    return newObj;
-  };
-
-  const handleChange = (key: string, value: string) => {
-    if (!person || !originalPersonRef.current) return;
-
-    const newPerson = setFieldValue(person, key, value);
-    setPerson(newPerson);
-
-    const originalValue = getFieldValue(originalPersonRef.current, key);
-    const newModified = new Set(modifiedFields);
-
-    if (value !== originalValue) {
-      newModified.add(key);
-    } else {
-      newModified.delete(key);
-    }
-    setModifiedFields(newModified);
-  };
-
+  // ---------------------------------------------------------------------------
+  // PHOTO HANDLING
+  // ---------------------------------------------------------------------------
+  /**
+   * Photo editor is a special case - it's not a standard input.
+   * We use setValue() to programmatically update the form value.
+   *
+   * setValue(name, value, options):
+   * - name: Field path (supports dot notation for nested fields)
+   * - value: New value
+   * - options.shouldDirty: Mark field as dirty (default: false)
+   * - options.shouldValidate: Run validation (default: false)
+   */
   const handlePhotoUpdate = (dataUrl: string) => {
-    if (!person) return;
-    const newPerson = { ...person, photo: dataUrl };
-    setPerson(newPerson);
-
-    const newModified = new Set(modifiedFields);
-    newModified.add("photo");
-    setModifiedFields(newModified);
+    setValue("photo", dataUrl, {
+      shouldDirty: true, // Important: marks the field as modified
+    });
     setShowPhotoEditor(false);
   };
 
-  const buildChanges = (): ProfileChange[] => {
-    const changes: ProfileChange[] = [];
+  // ---------------------------------------------------------------------------
+  // DIRTY FIELDS HELPER
+  // ---------------------------------------------------------------------------
+  /**
+   * dirtyFields is a nested object matching form structure.
+   * Example: { name: { first: true }, contactInfo: { email: true } }
+   *
+   * This helper flattens it to an array of dot-notation paths
+   * that match our fieldDefinitions keys.
+   */
+  const getDirtyFieldPaths = (): string[] => {
+    const paths: string[] = [];
 
-    modifiedFields.forEach((key) => {
-      const fieldDef = fieldDefinitions.find((f) => f.key === key);
-      if (fieldDef && person) {
+    // Check top-level fields
+    if (dirtyFields.birthDate) paths.push("birthDate");
+    if (dirtyFields.photo) paths.push("photo");
+
+    // Check nested name fields
+    if (dirtyFields.name) {
+      if (dirtyFields.name.first) paths.push("name.first");
+      if (dirtyFields.name.middle) paths.push("name.middle");
+      if (dirtyFields.name.last) paths.push("name.last");
+    }
+
+    // Check nested contactInfo fields
+    if (dirtyFields.contactInfo) {
+      const ci = dirtyFields.contactInfo;
+      if (ci.email) paths.push("contactInfo.email");
+      if (ci.address1) paths.push("contactInfo.address1");
+      if (ci.address2) paths.push("contactInfo.address2");
+      if (ci.city) paths.push("contactInfo.city");
+      if (ci.state) paths.push("contactInfo.state");
+      if (ci.zip) paths.push("contactInfo.zip");
+      if (ci.homePhone) paths.push("contactInfo.homePhone");
+      if (ci.mobilePhone) paths.push("contactInfo.mobilePhone");
+      if (ci.workPhone) paths.push("contactInfo.workPhone");
+    }
+
+    return paths;
+  };
+
+  /**
+   * Convert dirty field paths to human-readable labels for display.
+   */
+  const getModifiedFieldLabels = (): string[] => {
+    const labels: string[] = [];
+    const dirtyPaths = getDirtyFieldPaths();
+
+    dirtyPaths.forEach((path) => {
+      const fieldDef = fieldDefinitions.find((f) => f.key === path);
+      if (fieldDef) labels.push(fieldDef.label);
+    });
+
+    // Include family members (managed outside the form)
+    familyMembers.forEach(() => labels.push("New Family Member"));
+
+    return labels;
+  };
+
+  // ---------------------------------------------------------------------------
+  // FORM SUBMISSION
+  // ---------------------------------------------------------------------------
+  /**
+   * handleSubmit is an RHF wrapper that:
+   * 1. Prevents default form submission
+   * 2. Runs all validation
+   * 3. Only calls your function if validation passes
+   * 4. Passes validated, typed form data to your function
+   *
+   * The function receives FormData, not an event!
+   *
+   * isSubmitting is automatically true while this async function runs.
+   */
+  const onSubmit = async (data: ProfileFormData) => {
+    // Build changes array from dirty fields
+    const changes: ProfileChange[] = [];
+    const dirtyPaths = getDirtyFieldPaths();
+
+    dirtyPaths.forEach((path) => {
+      const fieldDef = fieldDefinitions.find((f) => f.key === path);
+      if (fieldDef) {
+        // Navigate the data object to get the value
+        let value: string;
+        if (path === "photo") {
+          value = data.photo;
+        } else if (path === "birthDate") {
+          value = data.birthDate;
+        } else if (path.startsWith("name.")) {
+          const key = path.split(".")[1] as keyof typeof data.name;
+          value = data.name[key];
+        } else if (path.startsWith("contactInfo.")) {
+          const key = path.split(".")[1] as keyof typeof data.contactInfo;
+          value = data.contactInfo[key];
+        } else {
+          value = "";
+        }
+
         changes.push({
-          field: key,
+          field: path,
           label: fieldDef.label,
-          value: key === "photo" ? person.photo || "" : getFieldValue(person, key),
+          value,
         });
       }
     });
 
+    // Add family members
     familyMembers.forEach((name) => {
       changes.push({
         field: "familyMember",
@@ -127,15 +381,9 @@ export const ProfileEdit: React.FC<Props> = (props) => {
       });
     });
 
-    return changes;
-  };
-
-  const handleSubmit = async () => {
-    const changes = buildChanges();
     if (changes.length === 0) return;
 
-    setSubmitting(true);
-
+    // Build and submit the task
     const task: TaskInterface = {
       dateCreated: new Date(),
       associatedWithType: "person",
@@ -150,9 +398,15 @@ export const ProfileEdit: React.FC<Props> = (props) => {
     };
 
     try {
-      const publicSettings = await ApiHelper.get(`/settings/public/${UserHelper.currentUserChurch.church.id}`, "MembershipApi");
+      const publicSettings = await ApiHelper.get(
+        `/settings/public/${UserHelper.currentUserChurch.church.id}`,
+        "MembershipApi"
+      );
       if (publicSettings?.directoryApprovalGroupId) {
-        const group: GroupInterface = await ApiHelper.get(`/groups/${publicSettings?.directoryApprovalGroupId}`, "MembershipApi");
+        const group: GroupInterface = await ApiHelper.get(
+          `/groups/${publicSettings?.directoryApprovalGroupId}`,
+          "MembershipApi"
+        );
         task.assignedToType = "group";
         task.assignedToId = publicSettings.directoryApprovalGroupId;
         task.assignedToLabel = group?.name;
@@ -160,30 +414,48 @@ export const ProfileEdit: React.FC<Props> = (props) => {
 
       await ApiHelper.post("/tasks?type=directoryUpdate", [task], "DoingApi");
       setSubmitted(true);
-      setModifiedFields(new Set());
+
+      // Reset form to current values (clears dirty state)
+      reset(data);
+
       if (props.onFamilyMembersChange) props.onFamilyMembersChange([]);
       if (props.onSave) props.onSave();
     } catch (error) {
       console.error("Error submitting profile changes:", error);
-    } finally {
-      setSubmitting(false);
     }
   };
 
-  const getModifiedFieldLabels = (): string[] => {
-    const labels: string[] = [];
-    modifiedFields.forEach((key) => {
-      const fieldDef = fieldDefinitions.find((f) => f.key === key);
-      if (fieldDef) labels.push(fieldDef.label);
-    });
-    familyMembers.forEach(() => labels.push("New Family Member"));
-    return labels;
-  };
+  // ---------------------------------------------------------------------------
+  // COMPUTED VALUES
+  // ---------------------------------------------------------------------------
+  const hasChanges = isDirty || familyMembers.length > 0;
 
-  const hasChanges = modifiedFields.size > 0 || familyMembers.length > 0;
+  // Get current photo value for display
+  // Note: We can't use watch("photo") easily here since we need original too
+  const currentPhoto = props.person?.photo;
 
-  if (!person) return null;
+  if (!props.person) return null;
 
+  // ---------------------------------------------------------------------------
+  // RENDER
+  // ---------------------------------------------------------------------------
+  /**
+   * CONTROLLER COMPONENT PATTERN
+   *
+   * MUI TextField is a "controlled component" that needs value/onChange props.
+   * RHF's register() works with native inputs via refs (uncontrolled).
+   *
+   * Controller bridges this gap:
+   * - name: Field path in the form (supports dot notation!)
+   * - control: The control object from useForm
+   * - render: Function that receives field props and fieldState
+   *
+   * The render function receives:
+   * - field: { onChange, onBlur, value, name, ref }
+   * - fieldState: { invalid, isTouched, isDirty, error }
+   *
+   * Spread {...field} onto your input to connect it to RHF.
+   */
   return (
     <Box>
       {submitted && (
@@ -197,190 +469,251 @@ export const ProfileEdit: React.FC<Props> = (props) => {
         <Box sx={{ mb: 3, "& .cropper-container": { overflow: "hidden !important" } }}>
           <ImageEditor
             aspectRatio={4 / 3}
-            photoUrl={person.photo?.startsWith("data:") ? person.photo : PersonHelper.getPhotoUrl(props.person)}
+            photoUrl={currentPhoto?.startsWith("data:") ? currentPhoto : PersonHelper.getPhotoUrl(props.person)}
             onCancel={() => setShowPhotoEditor(false)}
             onUpdate={handlePhotoUpdate}
           />
         </Box>
       )}
 
-      <Grid container spacing={3}>
-        {/* Photo Section */}
-        <Grid size={{ xs: 12, sm: 3 }}>
-          <Box sx={{ textAlign: "center" }}>
-            <Box
-              onClick={() => setShowPhotoEditor(true)}
-              sx={{ cursor: "pointer", "&:hover": { opacity: 0.8 } }}
-            >
-              <img
-                src={person.photo?.startsWith("data:") ? person.photo : PersonHelper.getPhotoUrl(props.person)}
-                alt="Profile"
-                style={{ maxWidth: "100%", borderRadius: 8 }}
-              />
-              <Typography variant="caption" color="textSecondary">
-                Click to change photo
-              </Typography>
+      {/*
+        handleSubmit wraps our onSubmit function.
+        It validates the form first and only calls onSubmit if valid.
+        TypeScript knows onSubmit receives ProfileFormData, not an event.
+      */}
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Grid container spacing={3}>
+          {/* Photo Section */}
+          <Grid size={{ xs: 12, sm: 3 }}>
+            <Box sx={{ textAlign: "center" }}>
+              <Box
+                onClick={() => setShowPhotoEditor(true)}
+                sx={{ cursor: "pointer", "&:hover": { opacity: 0.8 } }}
+              >
+                <img
+                  src={currentPhoto?.startsWith("data:") ? currentPhoto : PersonHelper.getPhotoUrl(props.person)}
+                  alt="Profile"
+                  style={{ maxWidth: "100%", borderRadius: 8 }}
+                />
+                <Typography variant="caption" color="textSecondary">
+                  Click to change photo
+                </Typography>
+              </Box>
             </Box>
-          </Box>
-        </Grid>
-
-        {/* Name Fields */}
-        <Grid size={{ xs: 12, sm: 9 }}>
-          <Grid container spacing={2}>
-            <Grid size={{ xs: 12, md: 4 }}>
-              <TextField
-                fullWidth
-                label="First Name"
-                value={getFieldValue(person, "name.first")}
-                onChange={(e) => handleChange("name.first", e.target.value)}
-              />
-            </Grid>
-            <Grid size={{ xs: 12, md: 4 }}>
-              <TextField
-                fullWidth
-                label="Middle Name"
-                value={getFieldValue(person, "name.middle")}
-                onChange={(e) => handleChange("name.middle", e.target.value)}
-              />
-            </Grid>
-            <Grid size={{ xs: 12, md: 4 }}>
-              <TextField
-                fullWidth
-                label="Last Name"
-                value={getFieldValue(person, "name.last")}
-                onChange={(e) => handleChange("name.last", e.target.value)}
-              />
-            </Grid>
           </Grid>
-        </Grid>
-      </Grid>
 
-      {/* Contact Section */}
-      <Typography variant="subtitle2" sx={{ mt: 3, mb: 1, fontWeight: 600, borderBottom: "1px solid #ddd", pb: 1 }}>
-        Contact
-      </Typography>
-      <Grid container spacing={2}>
-        <Grid size={{ xs: 12, md: 6 }}>
-          <TextField
-            fullWidth
-            label="Email"
-            type="email"
-            value={getFieldValue(person, "contactInfo.email")}
-            onChange={(e) => handleChange("contactInfo.email", e.target.value)}
-          />
-        </Grid>
-        <Grid size={{ xs: 12, md: 6 }}>
-          <TextField
-            fullWidth
-            label="Birth Date"
-            type="date"
-            InputLabelProps={{ shrink: true }}
-            value={getFieldValue(person, "birthDate")}
-            onChange={(e) => handleChange("birthDate", e.target.value)}
-          />
-        </Grid>
-      </Grid>
-
-      {/* Address and Phone Section */}
-      <Grid container spacing={3} sx={{ mt: 1 }}>
-        {/* Address */}
-        <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600, borderBottom: "1px solid #ddd", pb: 1 }}>
-            Address
-          </Typography>
-          <TextField
-            fullWidth
-            label="Address Line 1"
-            value={getFieldValue(person, "contactInfo.address1")}
-            onChange={(e) => handleChange("contactInfo.address1", e.target.value)}
-            sx={{ mb: 2 }}
-          />
-          <TextField
-            fullWidth
-            label="Address Line 2"
-            value={getFieldValue(person, "contactInfo.address2")}
-            onChange={(e) => handleChange("contactInfo.address2", e.target.value)}
-            sx={{ mb: 2 }}
-          />
-          <Grid container spacing={2}>
-            <Grid size={{ xs: 6 }}>
-              <TextField
-                fullWidth
-                label="City"
-                value={getFieldValue(person, "contactInfo.city")}
-                onChange={(e) => handleChange("contactInfo.city", e.target.value)}
-              />
-            </Grid>
-            <Grid size={{ xs: 3 }}>
-              <TextField
-                fullWidth
-                label="State"
-                value={getFieldValue(person, "contactInfo.state")}
-                onChange={(e) => handleChange("contactInfo.state", e.target.value)}
-              />
-            </Grid>
-            <Grid size={{ xs: 3 }}>
-              <TextField
-                fullWidth
-                label="Zip"
-                value={getFieldValue(person, "contactInfo.zip")}
-                onChange={(e) => handleChange("contactInfo.zip", e.target.value)}
-              />
+          {/* Name Fields */}
+          <Grid size={{ xs: 12, sm: 9 }}>
+            <Grid container spacing={2}>
+              {/*
+                CONTROLLER EXAMPLE - Nested field with dot notation
+                name="name.first" maps to form.name.first in the schema
+              */}
+              <Grid size={{ xs: 12, md: 4 }}>
+                <Controller
+                  name="name.first"
+                  control={control}
+                  render={({ field, fieldState }) => (
+                    <TextField
+                      {...field}
+                      fullWidth
+                      label="First Name"
+                      // fieldState.error comes from Zod validation
+                      error={!!fieldState.error}
+                      helperText={fieldState.error?.message}
+                    />
+                  )}
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <Controller
+                  name="name.middle"
+                  control={control}
+                  render={({ field, fieldState }) => (
+                    <TextField
+                      {...field}
+                      fullWidth
+                      label="Middle Name"
+                      error={!!fieldState.error}
+                      helperText={fieldState.error?.message}
+                    />
+                  )}
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <Controller
+                  name="name.last"
+                  control={control}
+                  render={({ field, fieldState }) => (
+                    <TextField
+                      {...field}
+                      fullWidth
+                      label="Last Name"
+                      error={!!fieldState.error}
+                      helperText={fieldState.error?.message}
+                    />
+                  )}
+                />
+              </Grid>
             </Grid>
           </Grid>
         </Grid>
 
-        {/* Phone */}
-        <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600, borderBottom: "1px solid #ddd", pb: 1 }}>
-            Phone
-          </Typography>
-          <TextField
-            fullWidth
-            label="Mobile Phone"
-            value={getFieldValue(person, "contactInfo.mobilePhone")}
-            onChange={(e) => handleChange("contactInfo.mobilePhone", e.target.value)}
-            sx={{ mb: 2 }}
-          />
-          <TextField
-            fullWidth
-            label="Home Phone"
-            value={getFieldValue(person, "contactInfo.homePhone")}
-            onChange={(e) => handleChange("contactInfo.homePhone", e.target.value)}
-            sx={{ mb: 2 }}
-          />
-          <TextField
-            fullWidth
-            label="Work Phone"
-            value={getFieldValue(person, "contactInfo.workPhone")}
-            onChange={(e) => handleChange("contactInfo.workPhone", e.target.value)}
-          />
+        {/* Contact Section */}
+        <Typography variant="subtitle2" sx={{ mt: 3, mb: 1, fontWeight: 600, borderBottom: "1px solid #ddd", pb: 1 }}>
+          Contact
+        </Typography>
+        <Grid container spacing={2}>
+          {/*
+            EMAIL FIELD - Shows Zod validation in action
+            The .email() validator in our schema provides automatic
+            error messages when the format is invalid.
+          */}
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Controller
+              name="contactInfo.email"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  fullWidth
+                  label="Email"
+                  type="email"
+                  error={!!fieldState.error}
+                  // Error message comes from Zod: "Invalid email format"
+                  helperText={fieldState.error?.message}
+                />
+              )}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Controller
+              name="birthDate"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  fullWidth
+                  label="Birth Date"
+                  type="date"
+                  InputLabelProps={{ shrink: true }}
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                />
+              )}
+            />
+          </Grid>
         </Grid>
-      </Grid>
 
-      {/* Modified Fields and Submit */}
-      <Box sx={{ mt: 3, p: 2, backgroundColor: hasChanges ? "#fff3cd" : "#f5f5f5", borderRadius: 1, border: hasChanges ? "1px solid #ffc107" : "1px solid #ddd" }}>
-        {hasChanges && (
-          <Typography variant="body2" sx={{ mb: 1 }}>
-            <strong>Modified:</strong> {getModifiedFieldLabels().join(", ")}
-          </Typography>
-        )}
-        <Box sx={{ display: "flex", gap: 1 }}>
-          {props.onCancel && (
-            <Button variant="outlined" onClick={props.onCancel}>
-              Cancel
-            </Button>
+        {/* Address and Phone Section */}
+        <Grid container spacing={3} sx={{ mt: 1 }}>
+          {/* Address */}
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600, borderBottom: "1px solid #ddd", pb: 1 }}>
+              Address
+            </Typography>
+            <Controller
+              name="contactInfo.address1"
+              control={control}
+              render={({ field }) => (
+                <TextField {...field} fullWidth label="Address Line 1" sx={{ mb: 2 }} />
+              )}
+            />
+            <Controller
+              name="contactInfo.address2"
+              control={control}
+              render={({ field }) => (
+                <TextField {...field} fullWidth label="Address Line 2" sx={{ mb: 2 }} />
+              )}
+            />
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 6 }}>
+                <Controller
+                  name="contactInfo.city"
+                  control={control}
+                  render={({ field }) => <TextField {...field} fullWidth label="City" />}
+                />
+              </Grid>
+              <Grid size={{ xs: 3 }}>
+                <Controller
+                  name="contactInfo.state"
+                  control={control}
+                  render={({ field }) => <TextField {...field} fullWidth label="State" />}
+                />
+              </Grid>
+              <Grid size={{ xs: 3 }}>
+                <Controller
+                  name="contactInfo.zip"
+                  control={control}
+                  render={({ field }) => <TextField {...field} fullWidth label="Zip" />}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+
+          {/* Phone */}
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600, borderBottom: "1px solid #ddd", pb: 1 }}>
+              Phone
+            </Typography>
+            <Controller
+              name="contactInfo.mobilePhone"
+              control={control}
+              render={({ field }) => (
+                <TextField {...field} fullWidth label="Mobile Phone" sx={{ mb: 2 }} />
+              )}
+            />
+            <Controller
+              name="contactInfo.homePhone"
+              control={control}
+              render={({ field }) => (
+                <TextField {...field} fullWidth label="Home Phone" sx={{ mb: 2 }} />
+              )}
+            />
+            <Controller
+              name="contactInfo.workPhone"
+              control={control}
+              render={({ field }) => <TextField {...field} fullWidth label="Work Phone" />}
+            />
+          </Grid>
+        </Grid>
+
+        {/* Modified Fields and Submit */}
+        <Box sx={{
+          mt: 3,
+          p: 2,
+          backgroundColor: hasChanges ? "#fff3cd" : "#f5f5f5",
+          borderRadius: 1,
+          border: hasChanges ? "1px solid #ffc107" : "1px solid #ddd"
+        }}>
+          {hasChanges && (
+            <Typography variant="body2" sx={{ mb: 1 }}>
+              <strong>Modified:</strong> {getModifiedFieldLabels().join(", ")}
+            </Typography>
           )}
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleSubmit}
-            disabled={submitting || !hasChanges}
-          >
-            {submitting ? "Submitting..." : "Submit for Approval"}
-          </Button>
+          <Box sx={{ display: "flex", gap: 1 }}>
+            {props.onCancel && (
+              <Button variant="outlined" onClick={props.onCancel} type="button">
+                Cancel
+              </Button>
+            )}
+            {/*
+              SUBMIT BUTTON
+              - type="submit" triggers form submission
+              - isSubmitting is automatically managed by RHF during async onSubmit
+              - No need for manual setSubmitting(true/false)!
+            */}
+            <Button
+              variant="contained"
+              color="primary"
+              type="submit"
+              disabled={isSubmitting || !hasChanges}
+            >
+              {isSubmitting ? "Submitting..." : "Submit for Approval"}
+            </Button>
+          </Box>
         </Box>
-      </Box>
+      </form>
     </Box>
   );
 };

--- a/src/components/notes/NewConversation.tsx
+++ b/src/components/notes/NewConversation.tsx
@@ -2,12 +2,11 @@
 
 import { Icon, Paper, Stack, TextField } from "@mui/material";
 import React from "react";
-import { useForm } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import { ApiHelper } from "@churchapps/apphelper";
 import { Locale } from "@churchapps/apphelper";
 import { PersonHelper } from "@churchapps/apphelper";
 import { ConversationInterface, UserContextInterface } from "@churchapps/helpers";
-import { ErrorMessages } from "@churchapps/apphelper";
 import { SmallButton } from "@churchapps/apphelper";
 
 interface Props {
@@ -26,10 +25,10 @@ interface FormData {
 
 export function NewConversation({ context, conversation, ...props }: Props) {
   const {
-    register,
+    control,
     handleSubmit,
     reset,
-    formState: { errors, isSubmitting }
+    formState: { isSubmitting }
   } = useForm<FormData>({
     defaultValues: { content: "" }
   });
@@ -68,29 +67,34 @@ export function NewConversation({ context, conversation, ...props }: Props) {
 
   const image = PersonHelper.getPhotoUrl(context?.person);
 
-  const errorMessages = errors.content ? [errors.content.message || Locale.label("notes.validate.content")] : [];
-
   return (
     <Paper sx={{ padding: 1, marginBottom: 2 }}>
-      <ErrorMessages errors={errorMessages} />
 
       <Stack direction="row" spacing={1.5} style={{ marginTop: 15 }} justifyContent="end">
 
         {image ? <img src={image} alt="user" style={{ width: 60, height: 45, borderRadius: 5, marginLeft: 8 }} /> : <Icon>person</Icon>}
         <Stack direction="column" spacing={2} style={{ width: "100%" }} justifyContent="end">
           <div><b>{context?.person?.name?.display}</b></div>
-          <TextField
-            fullWidth
-            aria-label={hasConversations ? "Type a message..." : Locale.label("notes.startConversation")}
-            placeholder={hasConversations ? "Type a message..." : Locale.label("notes.startConversation")}
-            multiline
-            style={{ marginTop: 0, border: "none" }}
-            variant="standard"
-            error={!!errors.content}
-            {...register("content", {
+          <Controller
+            name="content"
+            control={control}
+            rules={{
               required: Locale.label("notes.validate.content"),
               validate: (value) => value.trim() !== "" || Locale.label("notes.validate.content")
-            })}
+            }}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                fullWidth
+                aria-label={hasConversations ? "Type a message..." : Locale.label("notes.startConversation")}
+                placeholder={hasConversations ? "Type a message..." : Locale.label("notes.startConversation")}
+                multiline
+                style={{ marginTop: 0, border: "none" }}
+                variant="standard"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+              />
+            )}
           />
         </Stack>
         <Stack direction="column" spacing={1} justifyContent="end">

--- a/src/components/notes/NewConversation.tsx
+++ b/src/components/notes/NewConversation.tsx
@@ -2,10 +2,11 @@
 
 import { Icon, Paper, Stack, TextField } from "@mui/material";
 import React from "react";
+import { useForm } from "react-hook-form";
 import { ApiHelper } from "@churchapps/apphelper";
 import { Locale } from "@churchapps/apphelper";
 import { PersonHelper } from "@churchapps/apphelper";
-import { ConversationInterface, MessageInterface, UserContextInterface } from "@churchapps/helpers";
+import { ConversationInterface, UserContextInterface } from "@churchapps/helpers";
 import { ErrorMessages } from "@churchapps/apphelper";
 import { SmallButton } from "@churchapps/apphelper";
 
@@ -19,32 +20,23 @@ interface Props {
   conversation: ConversationInterface[]
 }
 
+interface FormData {
+  content: string;
+}
+
 export function NewConversation({ context, conversation, ...props }: Props) {
-  const [message, setMessage] = React.useState<MessageInterface>({})
-  const [errors, setErrors] = React.useState<string[]>([]);
-  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting }
+  } = useForm<FormData>({
+    defaultValues: { content: "" }
+  });
 
   const hasConversations = conversation?.length !== 0;
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
-    setErrors([]);
-    const m = { ...message } as MessageInterface;
-    m.content = e.target.value;
-    setMessage(m);
-  }
-
-  const validate = () => {
-    const result = [];
-    if (!message.content.trim()) result.push(Locale.label("notes.validate.content"));
-    setErrors(result);
-    return result.length === 0;
-  }
-
-  async function handleSave() {
-    if (!validate()) return;
-
-    setIsSubmitting(true);
-
+  async function onSubmit(data: FormData) {
     try {
       let cId: string;
 
@@ -64,33 +56,45 @@ export function NewConversation({ context, conversation, ...props }: Props) {
         cId = result[0].id;
       }
 
-      const m = { ...message, conversationId: cId };
-      await ApiHelper.post("/messages", [m], "MessagingApi");
+      const message = { content: data.content, conversationId: cId };
+      await ApiHelper.post("/messages", [message], "MessagingApi");
 
-      setMessage({ ...message, content: "" });
+      reset();
       props.onUpdate();
     } catch (error) {
       console.error("Error saving message:", error);
-    } finally {
-      setIsSubmitting(false);
     }
   }
 
   const image = PersonHelper.getPhotoUrl(context?.person);
 
+  const errorMessages = errors.content ? [errors.content.message || Locale.label("notes.validate.content")] : [];
+
   return (
     <Paper sx={{ padding: 1, marginBottom: 2 }}>
-      <ErrorMessages errors={errors} />
+      <ErrorMessages errors={errorMessages} />
 
       <Stack direction="row" spacing={1.5} style={{ marginTop: 15 }} justifyContent="end">
 
         {image ? <img src={image} alt="user" style={{ width: 60, height: 45, borderRadius: 5, marginLeft: 8 }} /> : <Icon>person</Icon>}
         <Stack direction="column" spacing={2} style={{ width: "100%" }} justifyContent="end">
           <div><b>{context?.person?.name?.display}</b></div>
-          <TextField fullWidth name="noteText" aria-label={hasConversations ? "Type a message..." : Locale.label("notes.startConversation")} placeholder={hasConversations ? "Type a message..." : Locale.label("notes.startConversation")} multiline style={{ marginTop: 0, border: "none" }} variant="standard" onChange={handleChange} value={message.content} />
+          <TextField
+            fullWidth
+            aria-label={hasConversations ? "Type a message..." : Locale.label("notes.startConversation")}
+            placeholder={hasConversations ? "Type a message..." : Locale.label("notes.startConversation")}
+            multiline
+            style={{ marginTop: 0, border: "none" }}
+            variant="standard"
+            error={!!errors.content}
+            {...register("content", {
+              required: Locale.label("notes.validate.content"),
+              validate: (value) => value.trim() !== "" || Locale.label("notes.validate.content")
+            })}
+          />
         </Stack>
         <Stack direction="column" spacing={1} justifyContent="end">
-          <SmallButton icon="send" onClick={handleSave} disabled={isSubmitting} />
+          <SmallButton icon="send" onClick={handleSubmit(onSubmit)} disabled={isSubmitting} />
         </Stack>
       </Stack>
     </Paper>


### PR DESCRIPTION
Replace manual useState-based form handling with React Hook Form:
- Remove useState for message, errors, and isSubmitting
- Use useForm hook with built-in validation and submission state
- Register TextField with required and trim validation rules
- Bridge RHF field errors to existing ErrorMessages component

This serves as a proof-of-concept for adopting RHF in B1App.
NewConversation.tsx was chosen as a minimal example.
ProfileEdit.tsx is the big example.
Not tested locally...