### PR TITLE
feat(test): allow BASE_URL override for Playwright

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: 'https://grace.demo.b1.church',
+    baseURL: process.env.BASE_URL || 'https://grace.demo.b1.church',
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'off',


### PR DESCRIPTION
## Summary

- Make `baseURL` in `playwright.config.ts` configurable via `process.env.BASE_URL`
- Falls back to `https://grace.demo.b1.church` when unset (no behavior change)
- Enables running Playwright E2E tests against local dev or staging environments

## Test plan

- [ ] `npx playwright test` — uses default demo URL
- [ ] `BASE_URL=http://localhost:3301 npx playwright test` — uses local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)