### PR TITLE
Switching from Admin to Member Portal

### DIFF
--- a/src/app/[sdSlug]/mobile/components/MobileDrawer.tsx
+++ b/src/app/[sdSlug]/mobile/components/MobileDrawer.tsx
@@ -11,6 +11,9 @@ import DarkModeIcon from "@mui/icons-material/DarkMode";
 import LightModeIcon from "@mui/icons-material/LightMode";
 import { type LinkInterface } from "@churchapps/helpers";
 import { Locale } from "@churchapps/apphelper";
+import { UserHelper } from "@churchapps/apphelper";
+import { Permissions } from "@churchapps/helpers";
+import { EnvironmentHelper } from "@/helpers";
 import UserContext from "@/context/UserContext";
 import { mobileTheme, linkTypeToIcon, linkTypeToRoute } from "./mobileTheme";
 import { getInitials } from "./util";
@@ -34,6 +37,16 @@ export const MobileDrawer = ({ links, onNavigate }: Props) => {
   const firstName = context?.person?.name?.first || context?.user?.firstName || "";
   const lastName = context?.person?.name?.last || context?.user?.lastName || "";
   const initials = getInitials({ name: { first: firstName, last: lastName } });
+  const canAccessAdmin = UserHelper.currentUserChurch && UserHelper.checkAccess(Permissions.contentApi.content.edit);
+
+  const adminUrl = React.useMemo(() => {
+    if (!canAccessAdmin || !context?.userChurch?.jwt || !context?.userChurch?.church?.id) return "";
+    const url = new URL("/login", EnvironmentHelper.Common.B1AdminRoot);
+    url.searchParams.set("jwt", context.userChurch.jwt);
+    url.searchParams.set("churchId", context.userChurch.church.id);
+    url.searchParams.set("returnUrl", "/");
+    return url.toString();
+  }, [canAccessAdmin, context?.userChurch?.jwt, context?.userChurch?.church?.id]);
 
   const isActive = (url: string): boolean => {
     if (!pathname || url.startsWith("http")) return false;
@@ -99,6 +112,40 @@ export const MobileDrawer = ({ links, onNavigate }: Props) => {
       </Box>
 
       <Box sx={{ flex: 1, overflowY: "auto" }}>
+        {canAccessAdmin && (
+          <Box
+            component="a"
+            href={adminUrl}
+            onClick={onNavigate}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              minHeight: 48,
+              px: `${mobileTheme.spacing.md}px`,
+              py: `${mobileTheme.spacing.sm + 4}px`,
+              borderBottom: `1px solid ${tc.border}`,
+              color: "inherit",
+              textDecoration: "none",
+              cursor: "pointer",
+              "&:hover": { bgcolor: tc.iconBackground }
+            }}
+          >
+            <Icon sx={{ fontSize: 24, color: tc.primary }}>settings</Icon>
+            <Typography sx={{
+              fontSize: 16,
+              fontWeight: 500,
+              color: tc.text,
+              flex: 1,
+              minWidth: 0,
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis"
+            }}>
+              {Locale.label("header.adminPortal")}
+            </Typography>
+          </Box>
+        )}
         {links.map((link, idx) => {
           if (link.linkType === "separator") {
             return <Divider key={`sep-${idx}`} sx={{ my: 1 }} />;

--- a/src/app/[sdSlug]/mobile/components/screens/LoginPage.tsx
+++ b/src/app/[sdSlug]/mobile/components/screens/LoginPage.tsx
@@ -57,6 +57,7 @@ export const MobileLoginScreen = ({ config }: Props) => {
   }, [pathname, config?.church?.subDomain]);
 
   const returnUrl = searchParams?.get("returnUrl") || "/mobile/dashboard";
+  const churchId = searchParams?.get("churchId") || undefined;
 
   const initialMode: Mode = (() => {
     const action = searchParams?.get("action");
@@ -118,7 +119,7 @@ export const MobileLoginScreen = ({ config }: Props) => {
   }, [resendCooldown]);
 
   const hydrateFromLoginResponse = (resp: LoginResponseInterface) =>
-    hydrateUserSession(resp, context, { sdSlug, writeCookies: true });
+    hydrateUserSession(resp, context, { sdSlug, churchId, writeCookies: true });
 
   const prefillRegisterFromMatch = async (emailToCheck: string) => {
     if (!emailToCheck || !EMAIL_REGEX.test(emailToCheck)) return;

--- a/src/app/[sdSlug]/mobile/hooks/hydrateUserSession.ts
+++ b/src/app/[sdSlug]/mobile/hooks/hydrateUserSession.ts
@@ -12,9 +12,8 @@ export interface SessionContext {
 }
 
 export interface HydrateOptions {
-
   sdSlug?: string;
-
+  churchId?: string;
   writeCookies?: boolean;
 }
 
@@ -23,7 +22,7 @@ export async function hydrateUserSession(
   context: SessionContext,
   options: HydrateOptions = {}
 ): Promise<any | null> {
-  const { sdSlug, writeCookies = false } = options;
+  const { sdSlug, churchId, writeCookies = false } = options;
 
   ApiHelper.setDefaultPermissions(resp.user.jwt);
   (resp.userChurches || []).forEach((uc: any) => { if (!uc.apis) uc.apis = []; });
@@ -31,11 +30,33 @@ export async function hydrateUserSession(
   UserHelper.userChurches = resp.userChurches || [];
 
   let matched: any = null;
-  if (sdSlug) {
+  if (churchId) {
+    matched = UserHelper.userChurches?.find((uc) => uc.church?.id === churchId);
+  }
+  if (!matched && sdSlug) {
     matched = UserHelper.userChurches?.find(
       (uc) => uc.church?.subDomain?.toLowerCase() === sdSlug.toLowerCase()
     );
   }
+
+  if (!matched && (churchId || sdSlug)) {
+    try {
+      const selectedChurch = await ApiHelper.post(
+        "/churches/select",
+        churchId ? { churchId } : { subDomain: sdSlug },
+        "MembershipApi"
+      );
+      if (selectedChurch) {
+        if (!selectedChurch.apis) selectedChurch.apis = [];
+        const existingIndex = UserHelper.userChurches.findIndex((uc: any) => uc.church?.id === selectedChurch.church?.id);
+        if (existingIndex >= 0) UserHelper.userChurches[existingIndex] = selectedChurch;
+        else UserHelper.userChurches.push(selectedChurch);
+        matched = selectedChurch;
+      }
+    } catch {
+    }
+  }
+
   const target = matched || UserHelper.userChurches?.[0];
   if (target) {
     UserHelper.currentUserChurch = target;
@@ -44,17 +65,23 @@ export async function hydrateUserSession(
 
   let person: any = null;
   const personId = UserHelper.currentUserChurch?.person?.id;
-  const churchId = UserHelper.currentUserChurch?.church?.id;
+  const currentChurchId = UserHelper.currentUserChurch?.church?.id;
   if (personId) {
     try {
       person = await ApiHelper.get(`/people/${personId}`, "MembershipApi");
     } catch {
-      if (churchId) {
-        try { person = await ApiHelper.get(`/people/claim/${churchId}`, "MembershipApi"); } catch { }
+      if (currentChurchId) {
+        try {
+          person = await ApiHelper.get(`/people/claim/${currentChurchId}`, "MembershipApi");
+        } catch {
+        }
       }
     }
-  } else if (churchId) {
-    try { person = await ApiHelper.get(`/people/claim/${churchId}`, "MembershipApi"); } catch { }
+  } else if (currentChurchId) {
+    try {
+      person = await ApiHelper.get(`/people/claim/${currentChurchId}`, "MembershipApi");
+    } catch {
+    }
   }
   if (person) {
     UserHelper.person = person;

--- a/src/app/[sdSlug]/mobile/hooks/useHydrateSession.ts
+++ b/src/app/[sdSlug]/mobile/hooks/useHydrateSession.ts
@@ -18,6 +18,37 @@ function readCookie(name: string): string | undefined {
   return match?.[1] ? decodeURIComponent(match[1]) : undefined;
 }
 
+function readQueryParam(name: string): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return new URLSearchParams(window.location.search).get(name) || undefined;
+}
+
+function clearAuthParamsFromUrl() {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  const hadJwt = url.searchParams.has("jwt");
+  const hadAuth = url.searchParams.has("auth");
+  if (!hadJwt && !hadAuth) return;
+  url.searchParams.delete("jwt");
+  url.searchParams.delete("auth");
+  const nextUrl = `${url.pathname}${url.search}${url.hash}`;
+  window.history.replaceState(window.history.state, "", nextUrl);
+}
+
+function getLoginPayload(): { jwt: string } | { authGuid: string } | null {
+  const authGuid = readQueryParam("auth");
+  if (authGuid) return { authGuid };
+
+  const jwt = readQueryParam("jwt") || readCookie("jwt");
+  if (jwt) return { jwt };
+
+  return null;
+}
+
+function getChurchId(): string | undefined {
+  return readQueryParam("churchId");
+}
+
 export function useHydrateSession(): HydrationStatus {
   const params = useParams<{ sdSlug?: string }>();
   const sdSlug = params?.sdSlug;
@@ -31,14 +62,17 @@ export function useHydrateSession(): HydrationStatus {
     let cancelled = false;
 
     const hydrate = async () => {
+      const loginPayload = getLoginPayload();
+      const churchId = getChurchId();
 
-      if (UserHelper.user?.id && UserHelper.currentUserChurch) {
+      // An explicit auth handoff in the URL should win over any existing
+      // in-memory session so account switching works reliably.
+      if (!loginPayload && UserHelper.user?.id && UserHelper.currentUserChurch) {
         if (!cancelled) setStatus("ready");
         return;
       }
 
-      const jwt = readCookie("jwt");
-      if (!jwt) {
+      if (!loginPayload) {
         if (!cancelled) setStatus("anonymous");
         return;
       }
@@ -48,7 +82,7 @@ export function useHydrateSession(): HydrationStatus {
       try {
         const resp: LoginResponseInterface = await ApiHelper.postAnonymous(
           "/users/login",
-          { jwt },
+          loginPayload,
           "MembershipApi"
         );
 
@@ -57,12 +91,12 @@ export function useHydrateSession(): HydrationStatus {
           return;
         }
 
-        await hydrateUserSession(resp, contextRef.current, { sdSlug });
+        await hydrateUserSession(resp, contextRef.current, { sdSlug, churchId, writeCookies: true });
 
         if (cancelled) return;
+        clearAuthParamsFromUrl();
         setStatus("ready");
-      } catch (err) {
-        console.warn("Mobile session rehydration failed:", err);
+      } catch {
         if (!cancelled) setStatus("anonymous");
       }
     };

--- a/src/app/[sdSlug]/mobile/page.tsx
+++ b/src/app/[sdSlug]/mobile/page.tsx
@@ -1,5 +1,20 @@
 import { redirect } from "next/navigation";
 
-export default function MobileRoot() {
-  redirect("/mobile/dashboard");
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+function buildQueryString(searchParams: Record<string, string | string[] | undefined>) {
+  const query = new URLSearchParams();
+
+  Object.entries(searchParams).forEach(([key, value]) => {
+    if (Array.isArray(value)) value.forEach((item) => query.append(key, item));
+    else if (typeof value === "string") query.set(key, value);
+  });
+
+  const result = query.toString();
+  return result ? `?${result}` : "";
+}
+
+export default async function MobileRoot({ searchParams }: { searchParams: SearchParams }) {
+  const queryString = buildQueryString(await searchParams);
+  redirect(`/mobile/dashboard${queryString}`);
 }


### PR DESCRIPTION
[Video Link Check once...📸](https://drive.google.com/file/d/1oigIVQOtxM57O-ftkRzfaWLN1AGzlAge/view?usp=sharing)

**Before:** 
Admin/B1 sent users to /mobile with auth params, but the redirect to /mobile/dashboard dropped jwt and churchId, so users landed logged out.

**After:** 
/mobile now keeps the query params during redirect, so jwt and churchId reach /mobile/dashboard, allowing auto-login via session hydration.

<img width="282" height="310" alt="image" src="https://github.com/user-attachments/assets/44260b90-f315-4797-9509-9acaf571c850" />

----

[BugLink](https://github.com/ChurchApps/ChurchAppsSupport/issues/865)
