### PR TITLE
Fix: sorting on directory and bible theme as b1App

### DIFF
--- a/src/app/[sdSlug]/mobile/components/screens/BiblePage.tsx
+++ b/src/app/[sdSlug]/mobile/components/screens/BiblePage.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from "react";
 import { Box, Button, Icon, Typography } from "@mui/material";
 import { mobileTheme } from "../mobileTheme";
+import { useMobileThemeMode } from "../MobileThemeProvider";
 
 const STORAGE_KEY = "b1.mobile.bible.selection";
 
@@ -132,6 +133,7 @@ export const BiblePage = () => {
   const [isClient, setIsClient] = useState(false);
   const [selection, setSelection] = useState<Selection>(DEFAULT_SELECTION);
   const [yv, setYv] = useState<YouVersionModule | null>(null);
+  const { mode } = useMobileThemeMode();
 
   useEffect(() => {
     let cancelled = false;
@@ -217,7 +219,7 @@ export const BiblePage = () => {
             minHeight: `calc(100vh - ${mobileTheme.headerHeight}px)`,
             bgcolor: tc.surface
           }}>
-            <yv.YouVersionProvider appKey={apiKey}>
+            <yv.YouVersionProvider appKey={apiKey} theme={mode}>
               <yv.BibleReader.Root
                 versionId={selection.versionId}
                 onVersionChange={(v: number) =>

--- a/src/app/[sdSlug]/mobile/components/screens/CommunityPage.tsx
+++ b/src/app/[sdSlug]/mobile/components/screens/CommunityPage.tsx
@@ -124,15 +124,15 @@ export const CommunityPage = ({ config: _config }: Props) => {
       const displayRaw = (p.name?.display || "").trim();
 
       let letter = "Other";
-      if (lastRaw) {
-        letter = lastRaw.charAt(0).toUpperCase();
+      if (firstRaw) {
+        letter = firstRaw.charAt(0).toUpperCase();
       } else if (displayRaw) {
 
         const parts = displayRaw.split(" ");
         const fallback = parts.length > 1 ? parts[parts.length - 1] : parts[0];
         if (fallback) letter = fallback.charAt(0).toUpperCase();
-      } else if (firstRaw) {
-        letter = firstRaw.charAt(0).toUpperCase();
+      } else if (lastRaw) {
+        letter = lastRaw.charAt(0).toUpperCase();
       }
 
       if (!/^[A-Z]$/.test(letter)) letter = "Other";


### PR DESCRIPTION
Fixes:
 - Bible theme as App theme
 - The directory was showing results based on the last name targets. It has now been prioritized to use the first name for listings, and if the first name lookup fails, it will fall back to the last name.


<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/2443eb7a-12ff-4a7b-b78c-c5685fa23988" />


### **Before**
<img width="1040" height="600" alt="Screenshot 2026-05-06 at 3 21 48 PM" src="https://github.com/user-attachments/assets/bb9327ff-4a68-4b56-99c4-210b4f6a7b40" />

### **After**
<img width="1040" height="600" alt="Screenshot 2026-05-06 at 3 19 25 PM" src="https://github.com/user-attachments/assets/5ff7a311-c276-4075-85d5-e2e5ec6e0ec4" />
