### PR TITLE
Fix/950 :- PageTitle issue

### DIFF
--- a/src/app/[sdSlug]/(public)/[pageSlug]/components/BiblePage.tsx
+++ b/src/app/[sdSlug]/(public)/[pageSlug]/components/BiblePage.tsx
@@ -7,7 +7,7 @@ import { YouVersionProvider, BibleReader } from "@youversion/platform-react-ui";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 
-function ChapterNavigation({ chapter, onChapterChange }: { chapter: string; onChapterChange: (chapter: string) => void }) {
+function ChapterNavigation({ chapter, onChapterChange, previousChapter, nextChapter }: { chapter: string; onChapterChange: (chapter: string) => void; previousChapter: string; nextChapter: string }) {
   const chapterNum = parseInt(chapter) || 1;
 
   const handlePrevious = () => {
@@ -22,17 +22,17 @@ function ChapterNavigation({ chapter, onChapterChange }: { chapter: string; onCh
     <Box sx={{ display: "flex", justifyContent: "center", gap: 2, mb: 2 }}>
       <ButtonGroup variant="outlined" size="large">
         <Button onClick={handlePrevious} disabled={chapterNum <= 1} startIcon={<ArrowBackIcon />} data-testid="bible-previous-chapter-button">
-          {Locale.label("pageSlug.previousChapter")}
+          {previousChapter}
         </Button>
         <Button onClick={handleNext} endIcon={<ArrowForwardIcon />} data-testid="bible-next-chapter-button">
-          {Locale.label("pageSlug.nextChapter")}
+          {nextChapter}
         </Button>
       </ButtonGroup>
     </Box>
   );
 }
 
-export function BiblePage() {
+export function BiblePage(props: { title: string, previousChapter: string, nextChapter: string }) {
   const apiKey = process.env.NEXT_PUBLIC_YOUVERSION_API_KEY || "kcjG9986IOT5ThXvd3lJT1DArk9RBlYt6gzAVNA8Lnb9a8Ld";
   const [chapter, setChapter] = useState("1");
   const [book, setBook] = useState("GEN");
@@ -40,12 +40,12 @@ export function BiblePage() {
 
   return (
     <Container>
-      <h1 style={{ textAlign: "center" }}>{Locale.label("pageSlug.bible")}</h1>
+      <h1 style={{ textAlign: "center" }}>{props.title}</h1>
       <YouVersionProvider appKey={apiKey}>
         <div style={{ marginTop: "20px" }}>
           <BibleReader.Root versionId={versionId} onVersionChange={setVersionId} book={book} onBookChange={setBook} chapter={chapter} onChapterChange={setChapter}>
             <BibleReader.Toolbar border="bottom" />
-            <ChapterNavigation chapter={chapter} onChapterChange={setChapter} />
+            <ChapterNavigation chapter={chapter} onChapterChange={setChapter} previousChapter={props.previousChapter} nextChapter={props.nextChapter} />
             <Box sx={{ maxHeight: "calc(100vh - 350px)", overflowY: "auto", padding: "20px", border: "1px solid #e0e0e0", borderRadius: "4px" }}>
               <BibleReader.Content />
             </Box>

--- a/src/app/[sdSlug]/(public)/[pageSlug]/components/DonatePage.tsx
+++ b/src/app/[sdSlug]/(public)/[pageSlug]/components/DonatePage.tsx
@@ -8,7 +8,14 @@ import { Button, Container, Grid, Icon, Link, Typography } from "@mui/material";
 import { redirect } from "next/navigation";
 import { CampaignProgress } from "@/components/donate/CampaignProgress";
 
-type Props = { config?: ConfigurationInterface; };
+type Props = {
+  config?: ConfigurationInterface;
+  title: string;
+  manageDonations: string;
+  achInstructions: string;
+  loginToManageDonations: string;
+  login: string;
+};
 
 export function DonatePage(props:Props) {
 
@@ -20,21 +27,21 @@ export function DonatePage(props:Props) {
   if (UserHelper.currentUserChurch?.person?.id) redirect("/mobile/donate");
   return <>
     <Container>
-      <h1>{Locale.label("pageSlug.donate")}</h1>
+      <h1>{props.title}</h1>
       {mounted && <CampaignProgress churchId={props.config?.church?.id || ""} />}
       <Grid container spacing={3}>
         <Grid size={{ md: 8, xs: 12 }}>
           {mounted && <NonAuthDonationWrapper churchId={props.config?.church?.id || ""} showHeader={false} />}
         </Grid>
         <Grid size={{ md: 4, xs: 12 }}>
-          <Typography component="h3" sx={{ textAlign: "center", fontSize: "30px", fontWeight: 500, lineHeight: 1.2, margin: "0 0 8px 0" }}>{Locale.label("pageSlug.manageDonations")}</Typography>
+          <Typography component="h3" sx={{ textAlign: "center", fontSize: "30px", fontWeight: 500, lineHeight: 1.2, margin: "0 0 8px 0" }}>{props.manageDonations}</Typography>
           <a href="https://support.churchapps.org/b1/portal/donations/" target="_blank" rel="noopener noreferrer" style={{ textDecoration: "underline", textUnderlineOffset: 2, display: "flex", justifyContent: "center", alignItems: "center", fontSize: "15px" }} data-testid="donate-instructions-link">
-            <p>{Locale.label("pageSlug.achInstructions")}</p>
+            <p>{props.achInstructions}</p>
             <Icon sx={{ fontSize: "18px !important", marginLeft: 0.5 }}>open_in_new</Icon>
           </a>
-          <p style={{ textAlign: "center", fontSize: "12.5px", marginBottom: 3, fontStyle: "italic" }}>{Locale.label("pageSlug.loginToManageDonations")}</p>
+          <p style={{ textAlign: "center", fontSize: "12.5px", marginBottom: 3, fontStyle: "italic" }}>{props.loginToManageDonations}</p>
           <Link href="/login/?returnUrl=/donate">
-            <Button sx={{ fontSize: "16px", textTransform: "capitalize" }} fullWidth variant="contained" data-testid="donate-login-button">{Locale.label("login.login")}</Button>
+            <Button sx={{ fontSize: "16px", textTransform: "capitalize" }} fullWidth variant="contained" data-testid="donate-login-button">{props.login}</Button>
           </Link>
         </Grid>
       </Grid>

--- a/src/app/[sdSlug]/(public)/[pageSlug]/components/StreamPage.tsx
+++ b/src/app/[sdSlug]/(public)/[pageSlug]/components/StreamPage.tsx
@@ -7,7 +7,8 @@ import { Container } from "@mui/material";
 
 
 type Props = {
-  config?: ConfigurationInterface
+  config?: ConfigurationInterface;
+  title: string;
 };
 
 export function StreamPage(props: Props) {
@@ -16,7 +17,7 @@ export function StreamPage(props: Props) {
 
   return (
     <Container>
-      <h1 style={{ textAlign: "center" }}>{Locale.label("pageSlug.liveStream")}</h1>
+      <h1 style={{ textAlign: "center" }}>{props.title}</h1>
       <LiveStream includeHeader={false} includeInteraction={true} keyName={props.config?.church?.subDomain || ""} appearance={props.config!.appearance} />
     </Container>
   );

--- a/src/app/[sdSlug]/(public)/[pageSlug]/components/VotdPage.tsx
+++ b/src/app/[sdSlug]/(public)/[pageSlug]/components/VotdPage.tsx
@@ -4,7 +4,7 @@ import { Container } from "@mui/material";
 import { Locale } from "@churchapps/apphelper";
 import { useState, useEffect } from "react";
 
-export function VotdPage() {
+export function VotdPage(props: { title: string }) {
   const [shape, setShape] = useState("16x9");
   const [day, setDay] = useState<number | null>(null);
   const [isClient, setIsClient] = useState(false);
@@ -44,7 +44,7 @@ export function VotdPage() {
   if (!isClient || day === null) {
     return (
       <Container>
-        <h1 style={{ textAlign: "center" }}>{Locale.label("pageSlug.verseOfTheDay")}</h1>
+        <h1 style={{ textAlign: "center" }}>{props.title}</h1>
         <div className="full-frame" style={{ minHeight: "200px" }} />
       </Container>
     );
@@ -52,11 +52,11 @@ export function VotdPage() {
 
   return (
     <Container>
-      <h1 style={{ textAlign: "center" }}>{Locale.label("pageSlug.verseOfTheDay")}</h1>
+      <h1 style={{ textAlign: "center" }}>{props.title}</h1>
       <img
         src={"https://votd.org/v1/" + day + "/" + shape + ".jpg"}
         className="full-frame"
-        alt={Locale.label("pageSlug.verseOfTheDay")}
+        alt={props.title}
       />
     </Container>
   );

--- a/src/app/[sdSlug]/(public)/[pageSlug]/page.tsx
+++ b/src/app/[sdSlug]/(public)/[pageSlug]/page.tsx
@@ -25,12 +25,12 @@ const VIRTUAL_PAGE_SLUGS = ["votd", "bible", "donate", "stream", "sermons"];
 type PageParams = Promise<{ sdSlug: string; pageSlug: string; }>
 
 // cache() shares one load between generateMetadata and the page render.
-const loadSharedData = cache((sdSlug:string, pageSlug:string) => {
-  EnvironmentHelper.init();
+const loadSharedData = cache(async (sdSlug: string, pageSlug: string) => {
+  await EnvironmentHelper.initServerSide();
   return loadData(sdSlug, pageSlug);
 });
 
-export async function generateMetadata({ params }: {params:PageParams}): Promise<Metadata> {
+export async function generateMetadata({ params }: { params: PageParams }): Promise<Metadata> {
   const { sdSlug, pageSlug } = await params;
   const props = await loadSharedData(sdSlug, pageSlug);
   let title = props.pageData.title;
@@ -48,14 +48,13 @@ export async function generateMetadata({ params }: {params:PageParams}): Promise
   return MetaHelper.getMetaData(pageTitle + " - " + props.config.church.name, description, undefined, props.config.appearance);
 }
 
-const loadData = async (sdSlug:string, pageSlug:string) => {
+const loadData = async (sdSlug: string, pageSlug: string) => {
   const config: ConfigurationInterface = await ConfigHelper.load(sdSlug, "website");
   const pageData = await fetchCachedOrNull<PageInterface>("/pages/" + config.church.id + "/tree?url=" + pageSlug + (config.siteId ? "&siteId=" + config.siteId : ""), "ContentApi", sdSlug);
   return { pageData: pageData || ({} as PageInterface), config };
 };
 
 export default async function Home({ params }: { params: PageParams }) {
-  await EnvironmentHelper.initServerSide();
   const { sdSlug, pageSlug } = await params;
   const { pageData, config } = await loadSharedData(sdSlug, pageSlug);
 
@@ -81,10 +80,10 @@ export default async function Home({ params }: { params: PageParams }) {
 
     if (!pageData?.url) {
       switch (pageSlug) {
-        case "votd": result = wrapDefaultPage(<VotdPage />); break;
-        case "bible": result = wrapDefaultPage(<BiblePage />); break;
-        case "donate": result = wrapDefaultPage(<DonatePage config={config} />); break;
-        case "stream": result = wrapDefaultPage(<StreamPage config={config} />); break;
+        case "votd": result = wrapDefaultPage(<VotdPage title={Locale.label("pageSlug.verseOfTheDay")} />); break;
+        case "bible": result = wrapDefaultPage(<BiblePage title={Locale.label("pageSlug.bible")} previousChapter={Locale.label("pageSlug.previousChapter")} nextChapter={Locale.label("pageSlug.nextChapter")} />); break;
+        case "donate": result = wrapDefaultPage(<DonatePage config={config} title={Locale.label("pageSlug.donate")} manageDonations={Locale.label("pageSlug.manageDonations")} achInstructions={Locale.label("pageSlug.achInstructions")} loginToManageDonations={Locale.label("pageSlug.loginToManageDonations")} login={Locale.label("login.login")} />); break;
+        case "stream": result = wrapDefaultPage(<StreamPage config={config} title={Locale.label("pageSlug.liveStream")} />); break;
         case "sermons": result = wrapDefaultPage(<SermonsPage config={config} title={Locale.label("pageSlug.sermons")} />); break;
         default: return notFound();
       }

--- a/src/app/[sdSlug]/(public)/page.tsx
+++ b/src/app/[sdSlug]/(public)/page.tsx
@@ -17,8 +17,8 @@ import { DefaultPageWrapper } from "./[pageSlug]/components/DefaultPageWrapper";
 type PageParams = { sdSlug: string; }
 
 
-const loadSharedData = (sdSlug: string) => {
-  EnvironmentHelper.init();
+const loadSharedData = async (sdSlug: string) => {
+  await EnvironmentHelper.initServerSide();
   return loadData(sdSlug);
 };
 
@@ -38,7 +38,6 @@ const loadData = async (sdSlug: string) => {
 };
 
 export default async function Home({ params }: { params: Promise<PageParams> }) {
-  await EnvironmentHelper.initServerSide();
   const { sdSlug } = await params;
   const props = await loadSharedData(sdSlug);
 

--- a/src/helpers/EnvironmentHelper.ts
+++ b/src/helpers/EnvironmentHelper.ts
@@ -46,7 +46,7 @@ export class EnvironmentHelper {
   };
 
   static initLocale = async () => {
-    let baseUrl = "https://ironwood.staging.b1.church";
+    let baseUrl = process.env.NEXT_PUBLIC_CHURCH_APPS_URL || "https://b1.church";
     if (typeof window !== "undefined") {
       baseUrl = window.location.origin;
     } else if (process.env.NEXT_PUBLIC_STAGE === "dev" || process.env.NEXT_STAGE === "dev") {


### PR DESCRIPTION
- Awaited EnvironmentHelper server-side initialization to ensure Locale translates correctly before page render
- Updated EnvironmentHelper fallback URL to NEXT_PUBLIC_CHURCH_APPS_URL to prevent silent locale fetch failures in production
- Passed translated strings as props to Bible, Donate, Stream, and Votd pages to eliminate hydration mismatches (1-second delay flash of 'pageSlug.xxx' text)


https://github.com/ChurchApps/ChurchAppsSupport/issues/950