### PR TITLE
Fix #970 bug

### DIFF
--- a/src/app/[sdSlug]/mobile/components/details/GroupDetail.tsx
+++ b/src/app/[sdSlug]/mobile/components/details/GroupDetail.tsx
@@ -76,7 +76,8 @@ const AuthenticatedGroupDetail = ({ idOrSlug, config }: { idOrSlug: string; conf
   const churchId = config.church.id;
   const [joining, setJoining] = React.useState(false);
   const [requestDialogOpen, setRequestDialogOpen] = React.useState(false);
-  const [tab, setTab] = React.useState<TabKey>("about");
+  // Initially show the Members tab to avoid the messaging screen popup caused by a mounting bug.
+  const [tab, setTab] = React.useState<TabKey>("members");
   const [chatOpen, setChatOpen] = React.useState(false);
   const [chatInitialTab, setChatInitialTab] = React.useState<ChatSubTab>("discussions");
   const [createEvent, setCreateEvent] = React.useState<string | null>(null);

--- a/src/app/[sdSlug]/mobile/components/details/GroupDetail.tsx
+++ b/src/app/[sdSlug]/mobile/components/details/GroupDetail.tsx
@@ -622,8 +622,11 @@ const AuthenticatedGroupDetail = ({ idOrSlug, config }: { idOrSlug: string; conf
 
   React.useEffect(() => {
     if (!group) return;
+    // Use Members as the initial tab to avoid the Messages modal mounting
+    // before the screen is ready. Users can switch to Messages afterward,
+    // allowing the modal to open correctly.
     if (!availableTabs.some((t) => t.key === tab)) {
-      setTab(availableTabs[0].key);
+      setTab('members');
     }
   }, [group, hasAbout, hasPlans, isMember, isLeader, tab]);
 


### PR DESCRIPTION
** ✅ Initially show the Members tab to avoid the messaging screen popup caused by a mounting bug.**

❌BEFORE
``` 
const [tab, setTab] = React.useState<TabKey>("about");
```
--- 

✅AFTER
```
  const [tab, setTab] = React.useState<TabKey>("members");
```