### PR TITLE
Noindex staging/demo B1App hosts (Search Console report)

### DIFF
--- a/src/app/[sdSlug]/(public)/layout.tsx
+++ b/src/app/[sdSlug]/(public)/layout.tsx
@@ -13,10 +13,19 @@ import { SiteWidgets } from "@/components/SiteWidgets";
 import { ChurchAnalytics } from "@/components/ChurchAnalytics";
 import { EnvironmentHelper } from "@/helpers/EnvironmentHelper";
 import { fetchCached } from "@/helpers/ConfigHelper";
+import { isNoindexHost } from "@/helpers/noindexHost";
+import { headers } from "next/headers";
+import type { Metadata } from "next";
 
 type LayoutParams = Promise<{ sdSlug: string }>;
 
 export const viewport = { themeColor: "#ffffff" };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const headerList = await headers();
+  if (isNoindexHost(headerList.get("x-forwarded-host") || headerList.get("host"))) return { robots: { index: false, follow: false } };
+  return {};
+}
 
 async function loadSiteSettings(sdSlug: string, churchId?: string): Promise<{ announcementRaw?: string; launcherRaw?: string; ga4MeasurementId?: string }> {
   if (!churchId) return {};

--- a/src/app/[sdSlug]/robots.txt/route.ts
+++ b/src/app/[sdSlug]/robots.txt/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest } from "next/server";
+import { isNoindexHost } from "@/helpers/noindexHost";
 
 export async function GET(request: NextRequest, context: { params: Promise<{ sdSlug: string }> }) {
   const { sdSlug } = await context.params;
   const host = request.headers.get("x-forwarded-host") || request.headers.get("host") || sdSlug + ".b1.church";
+  if (isNoindexHost(host)) {
+    return new Response("User-agent: *\nDisallow: /\n", { headers: { "Content-Type": "text/plain", "X-Robots-Tag": "noindex, nofollow" } });
+  }
   const proto = request.headers.get("x-forwarded-proto") || "https";
   const body = [
     "User-agent: *",

--- a/src/helpers/noindexHost.ts
+++ b/src/helpers/noindexHost.ts
@@ -1,0 +1,8 @@
+// B1App serves church tenants at {slug}.b1.church (prod), {slug}.staging.b1.church, and {slug}.demosite.b1.church.
+// Apex staging.b1.church and demo.b1.church are other apps (ChurchApps marketing / B1Admin) and never hit this code.
+const NOINDEX_SUFFIXES = [".staging.b1.church", ".demosite.b1.church"];
+
+export function isNoindexHost(hostHeader: string | null | undefined): boolean {
+  const host = (hostHeader || "").split(",")[0].split(":")[0].trim().toLowerCase();
+  return NOINDEX_SUFFIXES.some((suffix) => host.endsWith(suffix));
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { isNoindexHost } from "@/helpers/noindexHost";
 
 const INTERNAL_HOSTS = ["localhost", "b1.church", "localtest.me"];
 const INTERNAL_SUFFIXES = [".b1.church", ".localtest.me", ".localhost", ".up.railway.app", ".vercel.app"];
@@ -14,7 +15,7 @@ const apiBase = () => {
 };
 
 export async function middleware(req: NextRequest) {
-  const host = (req.headers.get("host") || "").split(":")[0].toLowerCase();
+  const host = (req.headers.get("x-forwarded-host") || req.headers.get("host") || "").split(",")[0].split(":")[0].trim().toLowerCase();
   const isInternal = !host || INTERNAL_HOSTS.includes(host) || INTERNAL_SUFFIXES.some((s) => host.endsWith(s));
 
   const headers = new Headers(req.headers);
@@ -36,5 +37,7 @@ export async function middleware(req: NextRequest) {
     }
     if (entry.site) headers.set("x-site", entry.site);
   }
-  return NextResponse.next({ request: { headers } });
+  const res = NextResponse.next({ request: { headers } });
+  if (isNoindexHost(host)) res.headers.set("X-Robots-Tag", "noindex, nofollow");
+  return res;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Investigation

Jeremy asked SEO to stop Google from indexing staging/demo hosts. Search Console (b1.church, last 28 days) shows **staging.b1.church** (10 clicks / 605 impressions) and **demo.b1.church** (9 clicks / 309 impressions). Those apex hosts are **not served by this repo**.

Live checks (2026-08-16):

| Host | What actually serves it | Likely repo |
|---|---|---|
| `firstbaptistslidell.b1.church` | Next.js on Vercel (`x-matched-path: /[sdSlug]`) | **This repo (B1App)** |
| `ironwood.staging.b1.church` | Same Next.js app, staging Vercel project | **This repo (B1App)** |
| `{slug}.demosite.b1.church` | Same Next.js app, production Vercel | **This repo (B1App)** |
| `staging.b1.church` | CRA static site on S3/CloudFront. Title “ChurchApps - Free, Open-Source Apps for Churches”. SSL cert CN=`churchapps.org`. Same etag as `staging.churchapps.org`. `robots.txt` is `Disallow:` (allow all). | **Not B1App.** Same bytes as `staging.churchapps.org`. Old ChurchApps marketing (CRA). `ChurchAppsWeb` is archived in [DeprecatedProjects](https://github.com/ChurchApps/DeprecatedProjects). Current [BrochureSites/B1.church](https://github.com/ChurchApps/BrochureSites) is Vite and deploys to **production** `b1.church` (`s3://b1-church-web`), not this host. |
| `demo.b1.church` | Vite SPA, title “B1.church Admin”, S3/CloudFront. `robots.txt` matches B1Admin’s `public/robots.txt` (`Disallow:` = allow all). B1Admin has `deploy-demo` → `s3://demo-chums-app`. | **[B1Admin](https://github.com/ChurchApps/B1Admin)** |
| `b1.church` (apex) | S3/CloudFront Vite marketing | **[BrochureSites](https://github.com/ChurchApps/BrochureSites)** (`B1.church/`) |
| `www.staging.b1.church` | Hits B1App staging (rewritten to `/www`, 500) | This repo |
| `www.demo.b1.church` | Does not resolve | — |

### churchapps.org

| Host | Served by this app? |
|---|---|
| `churchapps.org` | **Yes** — custom domain for the `churchapps` tenant (`x-nextjs-rewritten-path: /churchapps`). Left indexable. |
| `staging.churchapps.org` | **No** — identical S3/CloudFront CRA as `staging.b1.church`. Do not fix here. |

## What this PR changes

Host-based noindex for hosts this app **does** serve:

- `*.staging.b1.church` (staging env of church sites)
- `*.demosite.b1.church` (demo-site env of church sites)

Implementation:

- `X-Robots-Tag: noindex, nofollow` in middleware
- `robots.txt` returns `Disallow: /` on those hosts
- public layout metadata `robots: noindex` keyed off hostname

Production church sites (`firstbaptistslidell.b1.church`, etc.), `b1.church` marketing, and `churchapps.org` are unchanged. The whole `*.b1.church` pattern is not blocked.

## What will **not** be fixed by merging this

Search Console’s `staging.b1.church` and `demo.b1.church` pages will keep ranking until those other apps send noindex:

1. **demo.b1.church** — in [B1Admin](https://github.com/ChurchApps/B1Admin): change `public/robots.txt` from empty `Disallow:` to `Disallow: /`, and add `<meta name="robots" content="noindex, nofollow">` (or CloudFront `X-Robots-Tag`) on the demo/staging deploys only. Do not apply that to the prod Chums/B1Admin host.
2. **staging.b1.church** / **staging.churchapps.org** — same static CRA on S3/CloudFront. Add `X-Robots-Tag: noindex` on that CloudFront distribution and/or a `robots.txt` with `Disallow: /`. There is no live repo in BrochureSites that currently builds that CRA.

No extra refactors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-385eae66-b0b0-461e-a55f-eed73accac11?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-385eae66-b0b0-461e-a55f-eed73accac11&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

