### PR TITLE
Require current password to change password

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -737,6 +737,7 @@
       "couldNotUpdateDisplayName": "Could not update display name.",
       "couldNotUpdateEmail": "Could not update email.",
       "couldNotUpdatePassword": "Could not update password.",
+      "currentPassword": "Current password",
       "deleteConversation": "Delete conversation",
       "deleteNotification": "Delete notification",
       "detectingDevice": "Detecting your device…",

--- a/src/app/[sdSlug]/mobile/components/screens/ProfileEditPage.tsx
+++ b/src/app/[sdSlug]/mobile/components/screens/ProfileEditPage.tsx
@@ -175,6 +175,7 @@ export const ProfileEditPage = ({ config }: Props) => {
   const [newEmail, setNewEmail] = useState("");
   const [emailError, setEmailError] = useState<string | null>(null);
   const [savingEmail, setSavingEmail] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [passwordError, setPasswordError] = useState<string | null>(null);
@@ -442,6 +443,10 @@ export const ProfileEditPage = ({ config }: Props) => {
 
   const handleSavePassword = async () => {
     setPasswordError(null);
+    if (!currentPassword) {
+      setPasswordError("Current password is required.");
+      return;
+    }
     if (!newPassword || newPassword.length < 8) {
       setPasswordError("Password must be at least 8 characters.");
       return;
@@ -452,7 +457,8 @@ export const ProfileEditPage = ({ config }: Props) => {
     }
     setSavingPassword(true);
     try {
-      await ApiHelper.post("/users/updatePassword", { newPassword }, "MembershipApi");
+      await ApiHelper.post("/users/updatePassword", { currentPassword, newPassword }, "MembershipApi");
+      setCurrentPassword("");
       setNewPassword("");
       setConfirmPassword("");
       setSnack({ open: true, msg: Locale.label("mobile.screens.passwordUpdated"), severity: "success" });
@@ -987,6 +993,17 @@ export const ProfileEditPage = ({ config }: Props) => {
         {sectionHeader("Change Password", "lock")}
         <Box sx={{ display: "flex", flexDirection: "column", gap: `${mobileTheme.spacing.sm + 4}px` }}>
           <TextField
+            label={Locale.label("mobile.screens.currentPassword")}
+            value={currentPassword}
+            onChange={(e) => { setCurrentPassword(e.target.value); setPasswordError(null); }}
+            type="password"
+            inputProps={{ autoComplete: "current-password" }}
+            variant="outlined"
+            size="medium"
+            fullWidth
+            sx={inputSx}
+          />
+          <TextField
             label={Locale.label("mobile.screens.newPassword")}
             value={newPassword}
             onChange={(e) => { setNewPassword(e.target.value); setPasswordError(null); }}
@@ -1017,7 +1034,7 @@ export const ProfileEditPage = ({ config }: Props) => {
           <Button
             variant="contained"
             onClick={handleSavePassword}
-            disabled={savingPassword || !newPassword || !confirmPassword}
+            disabled={savingPassword || !currentPassword || !newPassword || !confirmPassword}
             sx={{
               bgcolor: tc.primary,
               borderRadius: `${mobileTheme.radius.md}px`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Logged-in password change now collects and sends `currentPassword` with `newPassword` so it still works after ChurchApps/Api#69.

Forgot-password / guid reset is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9892c783-a8ce-4d0e-b784-d2787a65ffb5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9892c783-a8ce-4d0e-b784-d2787a65ffb5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

