### PR TITLE
Play arrangement audio tracks in the plan song dialog

### DIFF
--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "المعاينة غير متاحة لهذا المحتوى.",
       "previewNotAvailableSection": "المعاينة غير متاحة لهذا القسم.",
       "releaseDate": "تاريخ الإصدار",
-      "startDate": "تاريخ البدء"
+      "startDate": "تاريخ البدء",
+      "audioTracks": "المقاطع الصوتية"
     },
     "screenTitles": {
       "bible": "الكتاب المقدس",

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Náhled pro tento obsah není k dispozici.",
       "previewNotAvailableSection": "Náhled pro tuto sekci není k dispozici.",
       "releaseDate": "Datum vydání",
-      "startDate": "Datum začátku"
+      "startDate": "Datum začátku",
+      "audioTracks": "Zvukové stopy"
     },
     "screenTitles": {
       "bible": "Bible",

--- a/public/locales/da.json
+++ b/public/locales/da.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Forhåndsvisning ikke tilgængelig for dette indhold.",
       "previewNotAvailableSection": "Forhåndsvisning ikke tilgængelig for denne sektion.",
       "releaseDate": "Udgivelsesdato",
-      "startDate": "Startdato"
+      "startDate": "Startdato",
+      "audioTracks": "Lydspor"
     },
     "screenTitles": {
       "bible": "Bibel",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Vorschau für diesen Inhalt nicht verfügbar.",
       "previewNotAvailableSection": "Vorschau für diesen Abschnitt nicht verfügbar.",
       "releaseDate": "Veröffentlichungsdatum",
-      "startDate": "Startdatum"
+      "startDate": "Startdatum",
+      "audioTracks": "Audiospuren"
     },
     "screenTitles": {
       "bible": "Bibel",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -681,6 +681,7 @@
       "deleteBlockoutTitle": "Delete blockout date?",
       "endDate": "End date",
       "files": "Files",
+      "audioTracks": "Audio Tracks",
       "audioUnsupported": "Your browser does not support audio playback.",
       "keySignature": "Key Signature",
       "keys": "Keys",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Vista previa no disponible para este contenido.",
       "previewNotAvailableSection": "Vista previa no disponible para esta sección.",
       "releaseDate": "Fecha de Lanzamiento",
-      "startDate": "Fecha de inicio"
+      "startDate": "Fecha de inicio",
+      "audioTracks": "Pistas de audio"
     },
     "screenTitles": {
       "bible": "Biblia",

--- a/public/locales/fi.json
+++ b/public/locales/fi.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Esikatselu ei ole saatavilla tälle sisällölle.",
       "previewNotAvailableSection": "Esikatselu ei ole saatavilla tälle osiolle.",
       "releaseDate": "Julkaisupäivä",
-      "startDate": "Alkamispäivä"
+      "startDate": "Alkamispäivä",
+      "audioTracks": "Ääniraidat"
     },
     "screenTitles": {
       "bible": "Raamattu",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Aperçu non disponible pour ce contenu.",
       "previewNotAvailableSection": "Aperçu non disponible pour cette section.",
       "releaseDate": "Date de sortie",
-      "startDate": "Date de début"
+      "startDate": "Date de début",
+      "audioTracks": "Pistes audio"
     },
     "screenTitles": {
       "bible": "Bible",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "इस सामग्री के लिए पूर्वावलोकन उपलब्ध नहीं है।",
       "previewNotAvailableSection": "इस अनुभाग के लिए पूर्वावलोकन उपलब्ध नहीं है।",
       "releaseDate": "रिलीज़ तिथि",
-      "startDate": "प्रारंभ तिथि"
+      "startDate": "प्रारंभ तिथि",
+      "audioTracks": "ऑडियो ट्रैक"
     },
     "screenTitles": {
       "bible": "बाइबिल",

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Ehhez a tartalomhoz nem érhető el előnézet.",
       "previewNotAvailableSection": "Ehhez a szakaszhoz nem érhető el előnézet.",
       "releaseDate": "Megjelenés dátuma",
-      "startDate": "Kezdő dátum"
+      "startDate": "Kezdő dátum",
+      "audioTracks": "Sávok"
     },
     "screenTitles": {
       "bible": "Biblia",

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Pratinjau tidak tersedia untuk konten ini.",
       "previewNotAvailableSection": "Pratinjau tidak tersedia untuk bagian ini.",
       "releaseDate": "Tanggal Rilis",
-      "startDate": "Tanggal mulai"
+      "startDate": "Tanggal mulai",
+      "audioTracks": "Trek audio"
     },
     "screenTitles": {
       "bible": "Alkitab",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Anteprima non disponibile per questo contenuto.",
       "previewNotAvailableSection": "Anteprima non disponibile per questa sezione.",
       "releaseDate": "Data di Pubblicazione",
-      "startDate": "Data di inizio"
+      "startDate": "Data di inizio",
+      "audioTracks": "Tracce audio"
     },
     "screenTitles": {
       "bible": "Bibbia",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "このコンテンツのプレビューは利用できません。",
       "previewNotAvailableSection": "このセクションのプレビューは利用できません。",
       "releaseDate": "リリース日",
-      "startDate": "開始日"
+      "startDate": "開始日",
+      "audioTracks": "音声トラック"
     },
     "screenTitles": {
       "bible": "聖書",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "이 콘텐츠에 대한 미리보기를 사용할 수 없습니다.",
       "previewNotAvailableSection": "이 섹션에 대한 미리보기를 사용할 수 없습니다.",
       "releaseDate": "발매일",
-      "startDate": "시작일"
+      "startDate": "시작일",
+      "audioTracks": "오디오 트랙"
     },
     "screenTitles": {
       "bible": "성경",

--- a/public/locales/lt.json
+++ b/public/locales/lt.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Šio turinio peržiūra nepasiekiama.",
       "previewNotAvailableSection": "Šios skilties peržiūra nepasiekiama.",
       "releaseDate": "Išleidimo data",
-      "startDate": "Pradžios data"
+      "startDate": "Pradžios data",
+      "audioTracks": "Garso takeliai"
     },
     "screenTitles": {
       "bible": "Biblija",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Voorbeeld niet beschikbaar voor deze inhoud.",
       "previewNotAvailableSection": "Voorbeeld niet beschikbaar voor deze sectie.",
       "releaseDate": "Releasedatum",
-      "startDate": "Startdatum"
+      "startDate": "Startdatum",
+      "audioTracks": "Audiosporen"
     },
     "screenTitles": {
       "bible": "Bijbel",

--- a/public/locales/no.json
+++ b/public/locales/no.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Forhåndsvisning ikke tilgjengelig for dette innholdet.",
       "previewNotAvailableSection": "Forhåndsvisning ikke tilgjengelig for denne seksjonen.",
       "releaseDate": "Utgivelsesdato",
-      "startDate": "Startdato"
+      "startDate": "Startdato",
+      "audioTracks": "Lydspor"
     },
     "screenTitles": {
       "bible": "Bibelen",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Podgląd nie jest dostępny dla tej treści.",
       "previewNotAvailableSection": "Podgląd nie jest dostępny dla tej sekcji.",
       "releaseDate": "Data wydania",
-      "startDate": "Data rozpoczęcia"
+      "startDate": "Data rozpoczęcia",
+      "audioTracks": "Ścieżki audio"
     },
     "screenTitles": {
       "bible": "Biblia",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Pré-visualização não disponível para este conteúdo.",
       "previewNotAvailableSection": "Pré-visualização não disponível para esta seção.",
       "releaseDate": "Data de Lançamento",
-      "startDate": "Data de início"
+      "startDate": "Data de início",
+      "audioTracks": "Faixas de áudio"
     },
     "screenTitles": {
       "bible": "Bíblia",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Предварительный просмотр недоступен для этого содержимого.",
       "previewNotAvailableSection": "Предварительный просмотр недоступен для этого раздела.",
       "releaseDate": "Дата выпуска",
-      "startDate": "Дата начала"
+      "startDate": "Дата начала",
+      "audioTracks": "Аудиодорожки"
     },
     "screenTitles": {
       "bible": "Библия",

--- a/public/locales/sk.json
+++ b/public/locales/sk.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Náhľad nie je dostupný pre tento obsah.",
       "previewNotAvailableSection": "Náhľad nie je dostupný pre túto sekciu.",
       "releaseDate": "Dátum vydania",
-      "startDate": "Dátum začiatku"
+      "startDate": "Dátum začiatku",
+      "audioTracks": "Zvukové stopy"
     },
     "screenTitles": {
       "bible": "Biblia",

--- a/public/locales/sl.json
+++ b/public/locales/sl.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Predogled ni na voljo za to vsebino.",
       "previewNotAvailableSection": "Predogled za ta razdelek ni na voljo.",
       "releaseDate": "Datum izdaje",
-      "startDate": "Začetni datum"
+      "startDate": "Začetni datum",
+      "audioTracks": "Zvočne sledi"
     },
     "screenTitles": {
       "bible": "Sveto pismo",

--- a/public/locales/sr.json
+++ b/public/locales/sr.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Преглед није доступан за овај садржај.",
       "previewNotAvailableSection": "Преглед није доступан за ову секцију.",
       "releaseDate": "Датум издавања",
-      "startDate": "Датум почетка"
+      "startDate": "Датум почетка",
+      "audioTracks": "Аудио нумере"
     },
     "screenTitles": {
       "bible": "Библија",

--- a/public/locales/ss.json
+++ b/public/locales/ss.json
@@ -691,7 +691,8 @@
       "previewNotAvailable": "Kubukwa kuseceleni akutfolakali kulokucuketfwe.",
       "previewNotAvailableSection": "Kubukwa kuseceleni akutfolakali kulesigaba.",
       "releaseDate": "Lusuku Lwekukhishwa",
-      "startDate": "Lusuku Lekucala"
+      "startDate": "Lusuku Lekucala",
+      "audioTracks": "Audio Tracks"
     },
     "screenTitles": {
       "bible": "Libhayibheli",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Förhandsgranskning inte tillgänglig för detta innehåll.",
       "previewNotAvailableSection": "Förhandsgranskning inte tillgänglig för detta avsnitt.",
       "releaseDate": "Utgivningsdatum",
-      "startDate": "Startdatum"
+      "startDate": "Startdatum",
+      "audioTracks": "Ljudspår"
     },
     "screenTitles": {
       "bible": "Bibeln",

--- a/public/locales/tl.json
+++ b/public/locales/tl.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Hindi available ang preview para sa content na ito.",
       "previewNotAvailableSection": "Hindi available ang preview para sa section na ito.",
       "releaseDate": "Petsa ng Release",
-      "startDate": "Petsa ng simula"
+      "startDate": "Petsa ng simula",
+      "audioTracks": "Mga audio track"
     },
     "screenTitles": {
       "bible": "Bibliya",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Bu içerik için önizleme mevcut değil.",
       "previewNotAvailableSection": "Bu bölüm için önizleme mevcut değil.",
       "releaseDate": "Yayın Tarihi",
-      "startDate": "Başlangıç tarihi"
+      "startDate": "Başlangıç tarihi",
+      "audioTracks": "Ses parçaları"
     },
     "screenTitles": {
       "bible": "İncil",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Попередній перегляд недоступний для цього вмісту.",
       "previewNotAvailableSection": "Попередній перегляд недоступний для цього розділу.",
       "releaseDate": "Дата випуску",
-      "startDate": "Дата початку"
+      "startDate": "Дата початку",
+      "audioTracks": "Аудіодоріжки"
     },
     "screenTitles": {
       "bible": "Біблія",

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "Không có bản xem trước cho nội dung này.",
       "previewNotAvailableSection": "Không có bản xem trước cho phần này.",
       "releaseDate": "Ngày phát hành",
-      "startDate": "Ngày bắt đầu"
+      "startDate": "Ngày bắt đầu",
+      "audioTracks": "Bản nhạc"
     },
     "screenTitles": {
       "bible": "Kinh Thánh",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -614,7 +614,8 @@
       "previewNotAvailable": "此内容无法预览。",
       "previewNotAvailableSection": "此部分没有可用预览。",
       "releaseDate": "发布日期",
-      "startDate": "开始日期"
+      "startDate": "开始日期",
+      "audioTracks": "音轨"
     },
     "screenTitles": {
       "bible": "圣经",

--- a/src/app/[sdSlug]/mobile/components/plans/SongDialog.tsx
+++ b/src/app/[sdSlug]/mobile/components/plans/SongDialog.tsx
@@ -26,6 +26,7 @@ export const SongDialog: React.FC<Props> = (props) => {
   const [songDetail, setSongDetail] = React.useState<SongDetailInterface | null>(null);
   const [products, setProducts] = React.useState<PraiseChartsProduct[]>([]);
   const [links, setLinks] = React.useState<LinkInterface[]>([]);
+  const [audioFiles, setAudioFiles] = React.useState<any[]>([]);
   const [keyOffset, setKeyOffset] = React.useState(0);
 
   const loadData = async () => {
@@ -37,6 +38,8 @@ export const SongDialog: React.FC<Props> = (props) => {
     setSong(s);
     const sd = await ApiHelper.get("/songDetails/" + arr.songDetailId, "ContentApi");
     setSongDetail(sd);
+    const files = await ApiHelper.get("/files/arrangement/" + arr.id, "ContentApi");
+    setAudioFiles(files || []);
   };
 
   useEffect(() => {
@@ -66,6 +69,15 @@ export const SongDialog: React.FC<Props> = (props) => {
       {l.url && isAudioUrl(l.url) && (
         <audio controls preload="metadata" style={{ width: "100%", display: "block", marginTop: 4 }} src={l.url} data-testid={`song-external-${i}-audio`} />
       )}
+    </li>))}
+  </ul>);
+
+  const listAudioFiles = () => (<ul>
+    {audioFiles.map((f, i) => (<li key={f.id}>
+      {f.fileName}
+      <audio controls preload="metadata" style={{ width: "100%", display: "block", marginTop: 4 }} src={f.contentPath} data-testid={`song-audio-${i}-audio`}>
+        {Locale.label("mobile.plans.audioUnsupported")}
+      </audio>
     </li>))}
   </ul>);
 
@@ -119,10 +131,14 @@ export const SongDialog: React.FC<Props> = (props) => {
       <DialogContent>
         <Grid container spacing={3}>
           <Grid size={{ xs: 12, md: 9 }}>
-            {(products?.length > 0 || links.length > 0) && <>
+            {(products?.length > 0 || links.length > 0 || audioFiles.length > 0) && <>
               <h3>{Locale.label("mobile.plans.files")}</h3>
               {listProducts()}
               {listLinks()}
+              {audioFiles.length > 0 && <>
+                <h4>{Locale.label("mobile.plans.audioTracks")}</h4>
+                {listAudioFiles()}
+              </>}
             </>}
 
 


### PR DESCRIPTION
## Summary
- Fetch /files/arrangement/{id} when opening a plan song.
- Render those tracks with the existing #960 inline audio player.

ChurchAppsSupport #961.

## Test plan
- [x] eslint + tsc --noEmit on SongDialog
- [ ] Open a scheduled song that has arrangement audio and confirm the tracks play