### PR TITLE
Apply church firstDayOfWeek on remaining B1 App calendars

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint --fix src/",
     "pretest": "node tests/setup/pretest.mjs",
     "test": "playwright test",
-    "test:unit": "node --experimental-strip-types --test tests/unit/contentSecurityPolicy.test.ts tests/unit/customContentSecurity.test.ts tests/unit/isAudioUrl.test.ts",
+    "test:unit": "node --experimental-strip-types --test tests/unit/contentSecurityPolicy.test.ts tests/unit/customContentSecurity.test.ts tests/unit/isAudioUrl.test.ts tests/unit/firstDayOfWeek.test.ts",
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
     "test:debug": "playwright test --debug",
@@ -26,7 +26,7 @@
     "postinstall": "copyfiles -a -f node_modules/@churchapps/apphelper/dist/public/locales/** public/apphelper/locales && copyfiles -a -f node_modules/@churchapps/apphelper/dist/markdown/components/htmlEditor/editor.css public/apphelper/css && copyfiles -a -f node_modules/react-cropper/node_modules/cropperjs/dist/cropper.css public/css && copyfiles -a -f node_modules/@churchapps/apphelper/dist/website/styles/animations.css node_modules/@churchapps/apphelper/dist/website/styles/pages.css src/styles/vendor && copyfiles -a -f node_modules/@churchapps/apphelper/dist/markdown/components/markdownEditor/editor.css public/apphelper/css/markdown && copyfiles -a -u 8 \"node_modules/@churchapps/apphelper/dist/markdown/components/markdownEditor/images/**/*\" public/apphelper/css/markdown/images"
   },
   "dependencies": {
-    "@churchapps/apphelper": "^1.1.2",
+    "@churchapps/apphelper": "^1.1.3",
     "@churchapps/content-providers": "^0.8.0",
     "@churchapps/helpers": "^2.1.0",
     "@emotion/react": "^11.14.0",

--- a/src/app/[sdSlug]/mobile/components/details/GroupDetail.tsx
+++ b/src/app/[sdSlug]/mobile/components/details/GroupDetail.tsx
@@ -16,6 +16,7 @@ import { MarkdownPreviewLight } from "@churchapps/apphelper/markdown";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Permissions, type GroupInterface, type PlanInterface } from "@churchapps/helpers";
 import { ConfigurationInterface } from "@/helpers/ConfigHelper";
+import { getFirstDayOfWeek } from "@/helpers/firstDayOfWeek";
 import { mobileTheme } from "../mobileTheme";
 import { getInitials } from "../util";
 import { GroupCalendarTab, type EventRow } from "../group/GroupCalendarTab";
@@ -707,7 +708,7 @@ const AuthenticatedGroupDetail = ({ idOrSlug, config }: { idOrSlug: string; conf
               isMember={isMember}
               onAddEvent={(dateIso) => setCreateEvent(dateIso)}
               onEditEvent={(ev) => setEditEvent(ev)}
-              firstDayOfWeek={(config.church as any)?.firstDayOfWeek || 0}
+              firstDayOfWeek={getFirstDayOfWeek(config.church)}
             />
           )}
           {tab === "attendance" && groupId && members !== null && (

--- a/src/app/[sdSlug]/mobile/components/group/GroupCalendarTab.tsx
+++ b/src/app/[sdSlug]/mobile/components/group/GroupCalendarTab.tsx
@@ -7,6 +7,7 @@ import { Box, Button, Chip, CircularProgress, Dialog, DialogContent, DialogTitle
 import { ApiHelper, Locale, PersonHelper, UserHelper } from "@churchapps/apphelper";
 import type { PersonInterface } from "@churchapps/helpers";
 import { EnvironmentHelper } from "@/helpers/EnvironmentHelper";
+import { rotateWeekdays, weekdayColumn } from "@/helpers/firstDayOfWeek";
 import { mobileTheme } from "../mobileTheme";
 import { EventProcessor } from "../../helpers/eventProcessor";
 import { MarkdownPreviewLight } from "@churchapps/apphelper/markdown";
@@ -203,16 +204,14 @@ export const GroupCalendarTab = ({ groupId, canManage, isMember, onAddEvent, onE
 
   const monthStart = startOfMonth(currentMonth);
   const monthEnd = endOfMonth(currentMonth);
-  const firstWeekdayRaw = monthStart.getDay();
-  const firstWeekday = (firstWeekdayRaw - firstDayOfWeek + 7) % 7;
+  const firstWeekday = weekdayColumn(monthStart.getDay(), firstDayOfWeek);
   const daysInMonth = monthEnd.getDate();
 
   const days: (Date | null)[] = [];
   for (let i = 0; i < firstWeekday; i++) days.push(null);
   for (let d = 1; d <= daysInMonth; d++) days.push(new Date(currentMonth.getFullYear(), currentMonth.getMonth(), d));
 
-  const baseLabels = ["S", "M", "T", "W", "T", "F", "S"];
-  const weekdayLabels = [...baseLabels.slice(firstDayOfWeek), ...baseLabels.slice(0, firstDayOfWeek)];
+  const weekdayLabels = rotateWeekdays(["S", "M", "T", "W", "T", "F", "S"], firstDayOfWeek);
 
   const goPrev = () => {
     const d = new Date(currentMonth);
@@ -435,6 +434,7 @@ export const GroupCalendarTab = ({ groupId, canManage, isMember, onAddEvent, onE
           {weekdayLabels.map((w, i) => (
             <Box
               key={`wd-${i}`}
+              data-testid={`weekday-${i}`}
               sx={{ textAlign: "center", fontSize: 12, fontWeight: 600, color: tc.primary, py: "4px" }}
             >
               {w}

--- a/src/helpers/firstDayOfWeek.ts
+++ b/src/helpers/firstDayOfWeek.ts
@@ -1,0 +1,21 @@
+// church.firstDayOfWeek is the single church-level setting (0=Sunday .. 6=Saturday)
+// applied to every calendar/week grid. See ChurchAppsSupport #985.
+
+/** Coerces any raw value (number, numeric string, undefined) to a valid 0-6 day index, defaulting to Sunday. */
+export const normalizeFirstDayOfWeek = (value: unknown): number => {
+  const n = typeof value === "string" ? Number(value) : value;
+  if (typeof n !== "number" || !Number.isInteger(n) || n < 0 || n > 6) return 0;
+  return n;
+};
+
+/** Reads firstDayOfWeek off a church record; the field is not yet declared on ChurchInterface, so any object is accepted. */
+export const getFirstDayOfWeek = (church?: object | null): number => normalizeFirstDayOfWeek((church as { firstDayOfWeek?: number | string } | undefined | null)?.firstDayOfWeek);
+
+/** Grid column (0-6) a JS Date.getDay() value lands in when the week starts on firstDayOfWeek. */
+export const weekdayColumn = (jsDay: number, firstDayOfWeek: number): number => (((jsDay % 7) + 7) % 7 - normalizeFirstDayOfWeek(firstDayOfWeek) + 7) % 7;
+
+/** Rotates a Sunday-first list of weekday labels so it starts on firstDayOfWeek. */
+export const rotateWeekdays = <T>(sundayFirstLabels: T[], firstDayOfWeek: number): T[] => {
+  const start = normalizeFirstDayOfWeek(firstDayOfWeek);
+  return [...sundayFirstLabels.slice(start), ...sundayFirstLabels.slice(0, start)];
+};

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -9,6 +9,7 @@ export { InstallPromptHelper } from "./InstallPromptHelper";
 export { formatNotificationError, getSocketDiagnostics } from "./NotificationRuntimeHelper";
 export { isLinkVisible, filterVisibleLinks } from "./VisibilityHelper";
 export { parseCustomJs, sanitizeCustomCss, ALLOWED_SCRIPT_HOSTS } from "./customContentSecurity";
+export { normalizeFirstDayOfWeek, getFirstDayOfWeek, weekdayColumn, rotateWeekdays } from "./firstDayOfWeek";
 export { PlanHelper } from "@churchapps/helpers";
 
 export * from "./interfaces";

--- a/tests/mobile-first-day.spec.ts
+++ b/tests/mobile-first-day.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, request, type Page, type APIRequestContext } from "@playwright/test";
+import { mobileLogoutButton } from "./helpers/mobile";
+
+// ChurchAppsSupport #985: church.firstDayOfWeek (0=Sun..6=Sat) drives the group
+// calendar week grid. Mutates the seeded church's setting, so runs serially and
+// restores the original value when done.
+const API_BASE = "http://localhost:8084";
+const CHURCH_ID = "CHU00000001";
+const GROUP_ID = "GRP00000004";
+const SUBDOMAIN = "grace";
+
+async function adminContext(): Promise<{ ctx: APIRequestContext; auth: { headers: { Authorization: string } } }> {
+  const ctx = await request.newContext();
+  const res = await ctx.post(`${API_BASE}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });
+  expect(res.ok()).toBeTruthy();
+  const body = await res.json();
+  const uc = (body.userChurches || []).find((c: any) => c.church?.id === CHURCH_ID) || body.userChurches?.[0];
+  const jwt = uc?.jwt as string;
+  expect(jwt, "admin jwt").toBeTruthy();
+  return { ctx, auth: { headers: { Authorization: "Bearer " + jwt } } };
+}
+
+async function setFirstDayOfWeek(value: number | undefined): Promise<void> {
+  const { ctx, auth } = await adminContext();
+  const churchRes = await ctx.get(`${API_BASE}/membership/churches/${CHURCH_ID}`, auth);
+  expect(churchRes.ok()).toBeTruthy();
+  const church = await churchRes.json();
+  const saveRes = await ctx.post(`${API_BASE}/membership/churches/`, { ...auth, data: [{ ...church, firstDayOfWeek: value }] });
+  expect(saveRes.ok(), `church save failed: ${saveRes.status()}`).toBeTruthy();
+  await ctx.dispose();
+}
+
+async function readWeekdayHeaders(page: Page): Promise<string[]> {
+  await page.goto(`/mobile/groups/${GROUP_ID}`);
+  await expect(mobileLogoutButton(page)).toBeVisible({ timeout: 30000 });
+  await page.getByRole("tab", { name: /Events/i }).click();
+  await expect(page.getByTestId("weekday-0")).toBeVisible({ timeout: 15000 });
+  const labels: string[] = [];
+  for (let i = 0; i < 7; i++) labels.push((await page.getByTestId(`weekday-${i}`).innerText()).trim());
+  return labels;
+}
+
+test.describe.serial("Group calendar first day of week", () => {
+  let originalFirstDay: number | undefined;
+
+  test.beforeAll(async () => {
+    const { ctx, auth } = await adminContext();
+    const res = await ctx.get(`${API_BASE}/membership/churches/${CHURCH_ID}`, auth);
+    expect(res.ok()).toBeTruthy();
+    originalFirstDay = (await res.json()).firstDayOfWeek;
+    await ctx.dispose();
+  });
+
+  test.afterAll(async () => {
+    await setFirstDayOfWeek(originalFirstDay);
+  });
+
+  test("church lookup exposes firstDayOfWeek", async () => {
+    await setFirstDayOfWeek(1);
+    const ctx = await request.newContext();
+    const res = await ctx.get(`${API_BASE}/membership/churches/lookup/?subDomain=${SUBDOMAIN}`);
+    expect(res.ok()).toBeTruthy();
+    expect((await res.json()).firstDayOfWeek).toBe(1);
+    await ctx.dispose();
+  });
+
+  test("Monday-first church renders the week grid starting on Monday", async ({ page }) => {
+    await setFirstDayOfWeek(1);
+    expect(await readWeekdayHeaders(page)).toEqual(["M", "T", "W", "T", "F", "S", "S"]);
+
+    // The first-of-month cell must land in the rotated column, not just relabel headers.
+    const now = new Date();
+    const first = new Date(now.getFullYear(), now.getMonth(), 1);
+    const iso = `${first.getFullYear()}-${String(first.getMonth() + 1).padStart(2, "0")}-01`;
+    const expectedColumn = (first.getDay() - 1 + 7) % 7;
+    const headerBox = await page.getByTestId(`weekday-${expectedColumn}`).boundingBox();
+    const dayBox = await page.getByTestId(`day-${iso}`).boundingBox();
+    expect(headerBox && dayBox).toBeTruthy();
+    const headerCenter = headerBox!.x + headerBox!.width / 2;
+    const dayCenter = dayBox!.x + dayBox!.width / 2;
+    expect(Math.abs(headerCenter - dayCenter)).toBeLessThan(headerBox!.width / 2);
+  });
+
+  test("Sunday-first church renders the default week grid", async ({ page }) => {
+    await setFirstDayOfWeek(0);
+    expect(await readWeekdayHeaders(page)).toEqual(["S", "M", "T", "W", "T", "F", "S"]);
+  });
+});

--- a/tests/test-ids.md
+++ b/tests/test-ids.md
@@ -91,6 +91,10 @@ This document contains all data-testid attributes found in the B1 Church codebas
 - `calendar-errors` - Calendar validation errors
 - `calendar-name-input` - Calendar name input
 
+### Group Calendar (Mobile)
+- `weekday-{0-6}` - Weekday header cells in the month grid, in church firstDayOfWeek order
+- `day-{yyyy-MM-dd}` - Day cells in the month grid
+
 ### Site Admin
 - `add-navigation-link` - Add navigation link button
 - `show-login-switch` - Show login toggle switch

--- a/tests/unit/firstDayOfWeek.test.ts
+++ b/tests/unit/firstDayOfWeek.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { normalizeFirstDayOfWeek, getFirstDayOfWeek, weekdayColumn, rotateWeekdays } from "../../src/helpers/firstDayOfWeek.ts";
+
+describe("normalizeFirstDayOfWeek", () => {
+  it("passes through valid day indexes", () => {
+    for (let d = 0; d <= 6; d++) assert.equal(normalizeFirstDayOfWeek(d), d);
+  });
+
+  it("accepts numeric strings from loosely-typed settings", () => {
+    assert.equal(normalizeFirstDayOfWeek("1"), 1);
+    assert.equal(normalizeFirstDayOfWeek("6"), 6);
+  });
+
+  it("defaults invalid values to Sunday", () => {
+    assert.equal(normalizeFirstDayOfWeek(undefined), 0);
+    assert.equal(normalizeFirstDayOfWeek(null), 0);
+    assert.equal(normalizeFirstDayOfWeek(-1), 0);
+    assert.equal(normalizeFirstDayOfWeek(7), 0);
+    assert.equal(normalizeFirstDayOfWeek(2.5), 0);
+    assert.equal(normalizeFirstDayOfWeek("monday"), 0);
+    assert.equal(normalizeFirstDayOfWeek(NaN), 0);
+  });
+});
+
+describe("getFirstDayOfWeek", () => {
+  it("reads the church setting", () => {
+    assert.equal(getFirstDayOfWeek({ firstDayOfWeek: 1 }), 1);
+  });
+
+  it("defaults to Sunday when the church or setting is missing", () => {
+    assert.equal(getFirstDayOfWeek(undefined), 0);
+    assert.equal(getFirstDayOfWeek(null), 0);
+    assert.equal(getFirstDayOfWeek({}), 0);
+  });
+});
+
+describe("weekdayColumn", () => {
+  it("is the identity for Sunday-first weeks", () => {
+    for (let d = 0; d <= 6; d++) assert.equal(weekdayColumn(d, 0), d);
+  });
+
+  it("shifts columns for Monday-first weeks", () => {
+    assert.equal(weekdayColumn(1, 1), 0); // Monday leads
+    assert.equal(weekdayColumn(0, 1), 6); // Sunday wraps to the end
+    assert.equal(weekdayColumn(6, 1), 5);
+  });
+
+  it("shifts columns for Saturday-first weeks", () => {
+    assert.equal(weekdayColumn(6, 6), 0);
+    assert.equal(weekdayColumn(0, 6), 1);
+    assert.equal(weekdayColumn(5, 6), 6);
+  });
+
+  it("always yields a valid column for every day/start combination", () => {
+    for (let start = 0; start <= 6; start++) {
+      const columns = new Set<number>();
+      for (let d = 0; d <= 6; d++) columns.add(weekdayColumn(d, start));
+      assert.equal(columns.size, 7);
+      assert.equal(weekdayColumn(start, start), 0);
+    }
+  });
+});
+
+describe("rotateWeekdays", () => {
+  const labels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+  it("keeps Sunday-first order by default", () => {
+    assert.deepEqual(rotateWeekdays(labels, 0), labels);
+  });
+
+  it("rotates to Monday-first", () => {
+    assert.deepEqual(rotateWeekdays(labels, 1), ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]);
+  });
+
+  it("rotates to Saturday-first", () => {
+    assert.deepEqual(rotateWeekdays(labels, 6), ["Sat", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri"]);
+  });
+
+  it("does not mutate the input", () => {
+    const copy = [...labels];
+    rotateWeekdays(labels, 3);
+    assert.deepEqual(labels, copy);
+  });
+
+  it("agrees with weekdayColumn: label at each column matches the day", () => {
+    for (let start = 0; start <= 6; start++) {
+      const rotated = rotateWeekdays(labels, start);
+      for (let d = 0; d <= 6; d++) assert.equal(rotated[weekdayColumn(d, start)], labels[d]);
+    }
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,9 +223,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@churchapps/apphelper@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@churchapps/apphelper@npm:1.1.2"
+"@churchapps/apphelper@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@churchapps/apphelper@npm:1.1.3"
   dependencies:
     "@emotion/cache": "npm:^11.14.0"
     "@emotion/react": "npm:^11.14.0"
@@ -287,7 +287,7 @@ __metadata:
       optional: true
     react-google-recaptcha:
       optional: true
-  checksum: 10c0/16f5f67e20e3173b1111b205167da149e6c2f16d74d31d9e7a007d0e252179ea56bc0e8fe94f3d3efe223280c63b30b3ab00958e4f9a5b80cf59c792861026bf
+  checksum: 10c0/76f4d24efed4363d22d485d3e5dadca2f4773e6686cdc0f7d59a0584d0105c868c068f2416d62bbe7db432872c7714afe29998f4d20ce409430dc8a6026b9ed3
   languageName: node
   linkType: hard
 
@@ -4267,7 +4267,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "b1-app@workspace:."
   dependencies:
-    "@churchapps/apphelper": "npm:^1.1.2"
+    "@churchapps/apphelper": "npm:^1.1.3"
     "@churchapps/content-providers": "npm:^0.8.0"
     "@churchapps/helpers": "npm:^2.1.0"
     "@emotion/react": "npm:^11.14.0"


### PR DESCRIPTION
## Summary
- Upgrade apphelper to 1.1.3 so website calendars honor church.firstDayOfWeek.
- Shared helper for mobile group calendar week rotation.
- Unit + Playwright tests. ChurchAppsSupport #985. Does not close the issue.
