### PR TITLE
Scroll to the URL fragment after client init (#1003)

### DIFF
--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -10,6 +10,7 @@ import { EnvironmentHelper } from "@/helpers";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { CookieProviderWrapper } from "@/components/CookieProviderWrapper";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
+import { useHashScroll } from "@/hooks/useHashScroll";
 
 
 
@@ -25,6 +26,8 @@ function ClientLayout({ children }: { children: React.ReactNode }) {
     // Error handling configuration
     ErrorHelper.init(getErrorAppData, customErrorHandler);
   }, []);
+
+  useHashScroll(localeInit);
 
 
   const getErrorAppData = () => {

--- a/src/app/[sdSlug]/mobile/MobileClientLayout.tsx
+++ b/src/app/[sdSlug]/mobile/MobileClientLayout.tsx
@@ -11,6 +11,7 @@ import { UserProvider } from "@/context/UserContext";
 import { MobileQueryProvider } from "./MobileQueryProvider";
 import MobileGoogleAnalytics from "./MobileGoogleAnalytics";
 import { useHydrateSession } from "./hooks/useHydrateSession";
+import { useHashScroll } from "@/hooks/useHashScroll";
 
 if (typeof window !== "undefined") EnvironmentHelper.init();
 
@@ -62,6 +63,8 @@ export function MobileClientLayout({ children }: { children: React.ReactNode }) 
       () => {}
     );
   }, []);
+
+  useHashScroll(localeReady);
 
   return (
     <CookieProviderWrapper>

--- a/src/hooks/useHashScroll.ts
+++ b/src/hooks/useHashScroll.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+
+// The browser's native jump-to-fragment happens during initial load; anything that renders
+// or re-renders page content afterwards (locale init, client-fetched elements) can strand it.
+export function useHashScroll(ready: boolean) {
+  useEffect(() => {
+    if (!ready || typeof window === "undefined") return;
+    const id = decodeURIComponent(window.location.hash.slice(1));
+    if (!id) return;
+
+    let timer = 0;
+    let cancelled = false;
+    const cancel = () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+    const deadline = Date.now() + 2000;
+    const attempt = () => {
+      if (cancelled) return;
+      const el = document.getElementById(id);
+      if (el) el.scrollIntoView();
+      else if (Date.now() < deadline) timer = window.setTimeout(attempt, 100);
+    };
+    requestAnimationFrame(() => requestAnimationFrame(attempt));
+
+    window.addEventListener("wheel", cancel, { passive: true });
+    window.addEventListener("touchmove", cancel, { passive: true });
+    window.addEventListener("keydown", cancel);
+    return () => {
+      cancel();
+      window.removeEventListener("wheel", cancel);
+      window.removeEventListener("touchmove", cancel);
+      window.removeEventListener("keydown", cancel);
+    };
+  }, [ready]);
+}

--- a/tests/issue-1003.spec.ts
+++ b/tests/issue-1003.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+
+// Mid-page section heading of the seeded Grace home page
+const ANCHOR_ID = "el-ELE00000029";
+
+const expectTargetInView = async (page: import("@playwright/test").Page) => {
+  await expect.poll(() => page.evaluate(() => window.scrollY), { timeout: 15000 }).toBeGreaterThan(100);
+  const box = await page.locator(`#${ANCHOR_ID}`).boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.y).toBeLessThan(page.viewportSize()!.height);
+  expect(box!.y + box!.height).toBeGreaterThan(0);
+};
+
+test.describe("Issue 1003 - fragment links scroll to their target", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+  });
+
+  test("loading a url with a hash leaves the target in view", async ({ page }) => {
+    await page.goto(`/#${ANCHOR_ID}`);
+    await expect(page.locator(`#${ANCHOR_ID}`)).toBeVisible();
+    await expectTargetInView(page);
+  });
+
+  test("re-scrolls to the target when hydration loses the native jump", async ({ page }) => {
+    // Delay the locale fetch so client init finishes well after load, then wipe the scroll
+    // position the way a late client render does in production.
+    await page.route("**/locales/**", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await route.continue();
+    });
+    await page.goto(`/#${ANCHOR_ID}`);
+    await expect(page.locator(`#${ANCHOR_ID}`)).toBeVisible();
+    await page.evaluate(() => window.scrollTo(0, 0));
+    expect(await page.evaluate(() => window.scrollY)).toBe(0);
+
+    await expectTargetInView(page);
+  });
+});


### PR DESCRIPTION
Links with a #fragment were landing at the top of the page. After the client finishes loading we now scroll to the hash target ourselves (desktop and /mobile).

Fixes ChurchApps/ChurchAppsSupport#1003