### PR TITLE
Gate the group attendance tab on the attendance permission (#1000)

### DIFF
--- a/src/app/[sdSlug]/mobile/components/details/GroupDetail.tsx
+++ b/src/app/[sdSlug]/mobile/components/details/GroupDetail.tsx
@@ -196,6 +196,8 @@ const AuthenticatedGroupDetail = ({ idOrSlug, config }: { idOrSlug: string; conf
   const isLeader = members !== null ? !!myMembership?.leader : !!seedGroup?.leader;
   const canEditResources = isLeader || UserHelper.checkAccess(Permissions.membershipApi.groups.edit);
   const canManageGroup = canEditResources;
+  // Mirrors the server gate: group leaders, or staff who actually hold the attendance permission
+  const canTakeAttendance = isLeader || UserHelper.checkAccess(Permissions.attendanceApi.attendance.edit);
 
   const handleMemberClick = (m: GroupMember) => {
     const pid = m.personId || m.person?.id;
@@ -618,7 +620,7 @@ const AuthenticatedGroupDetail = ({ idOrSlug, config }: { idOrSlug: string; conf
   if (hasPlans) availableTabs.push({ key: "plans", label: Locale.label("groupsPage.plans"), icon: "event_note" });
   if (isMember) availableTabs.push({ key: "messages", label: Locale.label("mobile.details.tabMessages"), icon: "forum" });
   availableTabs.push({ key: "members", label: Locale.label("mobile.details.membersTab"), icon: "group" });
-  if (canManageGroup) availableTabs.push({ key: "attendance", label: Locale.label("mobile.details.tabAttendance"), icon: "fact_check" });
+  if (canTakeAttendance) availableTabs.push({ key: "attendance", label: Locale.label("mobile.details.tabAttendance"), icon: "fact_check" });
   availableTabs.push({ key: "events", label: Locale.label("mobile.details.tabEvents"), icon: "event" });
   availableTabs.push({ key: "resources", label: Locale.label("mobile.details.tabResources"), icon: "folder" });
 
@@ -636,7 +638,7 @@ const AuthenticatedGroupDetail = ({ idOrSlug, config }: { idOrSlug: string; conf
     if (!availableTabs.some((t) => t.key === tab)) {
       setTab(defaultTab);
     }
-  }, [group, hasAbout, hasPlans, isMember, isLeader, tab]);
+  }, [group, hasAbout, hasPlans, isMember, isLeader, canTakeAttendance, tab]);
 
   return (
     <Box sx={{ p: `${mobileTheme.spacing.md}px`, bgcolor: tc.background, minHeight: "100%" }}>
@@ -714,7 +716,7 @@ const AuthenticatedGroupDetail = ({ idOrSlug, config }: { idOrSlug: string; conf
               firstDayOfWeek={getFirstDayOfWeek(config.church)}
             />
           )}
-          {tab === "attendance" && groupId && members !== null && (
+          {tab === "attendance" && canTakeAttendance && groupId && members !== null && (
             <GroupAttendanceTab
               groupId={groupId}
               members={(members || [])

--- a/tests/issue-1000.spec.ts
+++ b/tests/issue-1000.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, request, type Page } from "@playwright/test";
+
+const MAIN_API = "http://localhost:8084";
+const CHURCH_ID = "CHU00000001";
+// volunteer@b1.church (Rachel Martin) is a plain member of GRP00000025 and the leader of GRP00000029
+const MEMBER_GROUP = "GRP00000025";
+const LEADER_GROUP = "GRP00000029";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+async function loginAs(page: Page, email: string) {
+  await page.goto("/login", { timeout: 60000 });
+  await page.locator('input[type="email"]').waitFor({ state: "visible", timeout: 30000 });
+  await page.fill('input[type="email"]', email);
+  await page.fill('input[type="password"]', "password");
+  await page.click('button[type="submit"]');
+  await page.waitForURL((url) => !url.pathname.includes("/login"), { timeout: 30000 });
+}
+
+const attendanceTab = (page: Page) => page.getByRole("tab", { name: /Attendance/i });
+
+test.describe("Issue 1000 - attendance taking is leaders only", () => {
+  test("a plain group member does not get the attendance tab", async ({ page }) => {
+    await loginAs(page, "volunteer@b1.church");
+    await page.goto(`/mobile/groups/${MEMBER_GROUP}`);
+    await expect(page.getByRole("tab", { name: /Members/i })).toBeVisible({ timeout: 20000 });
+    await expect(attendanceTab(page)).toHaveCount(0);
+  });
+
+  test("a plain group member cannot deep link into attendance", async ({ page }) => {
+    const attendanceCalls: string[] = [];
+    page.on("request", (r) => {
+      if (r.url().includes("/attendance/")) attendanceCalls.push(r.url());
+    });
+    await loginAs(page, "volunteer@b1.church");
+    await page.goto(`/mobile/groups/${MEMBER_GROUP}?activeTab=attendance`);
+    await expect(page.getByRole("tab", { name: /Members/i })).toBeVisible({ timeout: 20000 });
+    await expect(attendanceTab(page)).toHaveCount(0);
+    expect(attendanceCalls).toEqual([]);
+  });
+
+  test("a group leader still gets the attendance tab", async ({ page }) => {
+    await loginAs(page, "volunteer@b1.church");
+    await page.goto(`/mobile/groups/${LEADER_GROUP}`);
+    await expect(attendanceTab(page)).toBeVisible({ timeout: 20000 });
+  });
+
+  test("staff without the attendance permission do not get it either", async ({ page }) => {
+    const ctx = await request.newContext();
+    const login = await ctx.post(`${MAIN_API}/membership/users/login`, {
+      data: { email: "demo@b1.church", password: "password" },
+      headers: { "Content-Type": "application/json" }
+    });
+    const uc = (await login.json()).userChurches.find((c: any) => c.church?.id === CHURCH_ID);
+    const jwt = uc.apis.find((a: any) => a.keyName === "MembershipApi").jwt;
+    const headers = { Authorization: `Bearer ${jwt}`, "Content-Type": "application/json" };
+
+    const roles = await (await ctx.post(`${MAIN_API}/membership/roles`, { headers, data: [{ name: `issue-1000 groups-only ${Date.now()}` }] })).json();
+    const roleId = roles[0].id;
+    try {
+      await ctx.post(`${MAIN_API}/membership/rolepermissions`, {
+        headers,
+        data: [{ roleId, apiName: "MembershipApi", contentType: "Groups", action: "Edit" }]
+      });
+      await ctx.post(`${MAIN_API}/membership/rolemembers`, {
+        headers,
+        data: [{ roleId, user: { email: "volunteer@b1.church" } }]
+      });
+
+      await loginAs(page, "volunteer@b1.church");
+      await page.goto(`/mobile/groups/${MEMBER_GROUP}`);
+      await expect(page.getByRole("tab", { name: /Members/i })).toBeVisible({ timeout: 20000 });
+      await expect(attendanceTab(page)).toHaveCount(0);
+    } finally {
+      await ctx.delete(`${MAIN_API}/membership/roles/${roleId}`, { headers });
+      await ctx.dispose();
+    }
+  });
+});


### PR DESCRIPTION
The group Attendance tab now only shows for group leaders or staff with attendance edit, matching what the API already enforces.

Fixes ChurchApps/ChurchAppsSupport#1000