### PR TITLE
Show the assigned volunteer next to order-of-service items

### DIFF
--- a/src/app/[sdSlug]/mobile/components/details/PlanDetail.tsx
+++ b/src/app/[sdSlug]/mobile/components/details/PlanDetail.tsx
@@ -196,6 +196,22 @@ export const PlanDetail = ({ id, config: _config }: Props) => {
     return groups;
   }, [positions]);
 
+  const positionLabels = useMemo(() => {
+    if (!plan?.showVolunteerNames) return {};
+    const result: Record<string, string> = {};
+    positions.forEach((p) => {
+      const names = assignments
+        .filter((a) => a.positionId === p.id)
+        .map((a) => {
+          const person = ArrayHelper.getOne(people, "id", a.personId) as PersonInterface | null;
+          return person?.name?.display || [person?.name?.first, person?.name?.last].filter(Boolean).join(" ");
+        })
+        .filter(Boolean);
+      if (p.id && names.length > 0) result[p.id] = names.join(", ");
+    });
+    return result;
+  }, [plan?.showVolunteerNames, positions, assignments, people]);
+
   const myAssignments = useMemo(
     () => (myPersonId ? ArrayHelper.getAll(assignments, "personId", myPersonId) : []),
     [assignments, myPersonId]
@@ -554,6 +570,7 @@ export const PlanDetail = ({ id, config: _config }: Props) => {
                   associatedProviderId={plan.providerId}
                   associatedVenueId={plan.providerPlanId}
                   ministryId={plan.ministryId}
+                  positionLabels={positionLabels}
                 />
               ))}
             </Box>

--- a/src/app/[sdSlug]/mobile/components/plans/PlanItem.tsx
+++ b/src/app/[sdSlug]/mobile/components/plans/PlanItem.tsx
@@ -13,6 +13,7 @@ interface Props {
   associatedProviderId?: string;
   associatedVenueId?: string;
   ministryId?: string;
+  positionLabels?: Record<string, string>;
 }
 
 export const PlanItem = (props: Props) => {
@@ -21,6 +22,7 @@ export const PlanItem = (props: Props) => {
   const [actionId, setActionId] = React.useState<string | null>(null);
 
   const pi = props.planItem;
+  const positionName = pi.positionId ? props.positionLabels?.[pi.positionId] : undefined;
   const hasProviderFields = pi.providerId && pi.providerPath && pi.providerContentPath;
 
   const getChildren = () => {
@@ -36,6 +38,7 @@ export const PlanItem = (props: Props) => {
           associatedProviderId={props.associatedProviderId}
           associatedVenueId={props.associatedVenueId}
           ministryId={props.ministryId}
+          positionLabels={props.positionLabels}
         />
       );
       cumulativeTime += c.seconds || 0;
@@ -54,6 +57,7 @@ export const PlanItem = (props: Props) => {
           </span>
         </span>
         <span>{pi.label}</span>
+        {positionName && <span className="planItemPosition" style={{ color: "#666", fontSize: "0.85em", marginLeft: 8 }}>{positionName}</span>}
       </div>
       {getChildren()}
     </>;
@@ -84,6 +88,7 @@ export const PlanItem = (props: Props) => {
         )}
       </div>
       {getDescriptionRow()}
+      {positionName && <div className="planItemPosition" style={{ color: "#666", fontSize: "0.85em", textAlign: "right" }}>{positionName}</div>}
     </div>
   </>;
 

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -268,6 +268,7 @@ export interface PlanItemInterface {
   providerPath?: string,
   providerContentPath?: string,
   thumbnailUrl?: string,
+  positionId?: string,
 
   children?: PlanItemInterface[]
 }

--- a/src/types/churchapps-helpers.d.ts
+++ b/src/types/churchapps-helpers.d.ts
@@ -8,4 +8,13 @@ declare module "@churchapps/helpers" {
   interface GroupInterface {
     campusId?: string;
   }
+
+  // Remove once @churchapps/helpers is republished with ChurchApps/Packages#24.
+  interface PlanItemInterface {
+    positionId?: string;
+  }
+
+  interface PlanInterface {
+    showVolunteerNames?: boolean;
+  }
 }

--- a/tests/issue-988.spec.ts
+++ b/tests/issue-988.spec.ts
@@ -1,0 +1,73 @@
+import { request as pwRequest, type APIRequestContext } from "@playwright/test";
+import { test, expect } from "@playwright/test";
+
+// Issue #988: the member-facing plan view shows the volunteer assigned to each
+// order-of-service item, gated by the plan's showVolunteerNames toggle.
+const API = "http://localhost:8084";
+const PERSON_ID = "PER00000001";
+const PERSON_NAME = "John Smith";
+
+async function apiLogin(ctx: APIRequestContext): Promise<string> {
+  const res = await ctx.post(`${API}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });
+  expect(res.ok()).toBeTruthy();
+  const body = await res.json();
+  const uc = (body.userChurches || []).find((c: any) => c.church?.id === "CHU00000001") || body.userChurches?.[0];
+  expect(uc?.jwt).toBeTruthy();
+  return uc.jwt as string;
+}
+
+test.describe("Mobile plan detail - assigned volunteer", () => {
+  let ctx: APIRequestContext;
+  let jwt: string;
+  let planId: string;
+
+  test.beforeAll(async () => {
+    ctx = await pwRequest.newContext();
+    jwt = await apiLogin(ctx);
+    const auth = { headers: { Authorization: "Bearer " + jwt } };
+
+    const planRes = await ctx.post(`${API}/doing/plans`, {
+      ...auth,
+      data: [{ name: "Issue988 Member Plan", ministryId: "GRP0000000a", serviceDate: "2030-06-01", serviceOrder: true, showVolunteerNames: true }]
+    });
+    expect(planRes.ok()).toBeTruthy();
+    planId = (await planRes.json())[0].id;
+
+    const posRes = await ctx.post(`${API}/doing/positions`, {
+      ...auth,
+      data: [{ planId, categoryName: "Issue988 Team", name: "Issue988 Speaker", count: 1 }]
+    });
+    expect(posRes.ok()).toBeTruthy();
+    const positionId = (await posRes.json())[0].id;
+
+    const assignRes = await ctx.post(`${API}/doing/assignments`, {
+      ...auth,
+      data: [{ positionId, personId: PERSON_ID, status: "Accepted" }]
+    });
+    expect(assignRes.ok()).toBeTruthy();
+
+    const headerRes = await ctx.post(`${API}/doing/planItems`, {
+      ...auth,
+      data: [{ planId, sort: 1, itemType: "header", label: "Issue988 Section" }]
+    });
+    expect(headerRes.ok()).toBeTruthy();
+    const headerId = (await headerRes.json())[0].id;
+
+    const itemRes = await ctx.post(`${API}/doing/planItems`, {
+      ...auth,
+      data: [{ planId, parentId: headerId, sort: 1, itemType: "item", label: "Issue988 Sermon", seconds: 600, positionId }]
+    });
+    expect(itemRes.ok()).toBeTruthy();
+  });
+
+  test.afterAll(async () => {
+    if (planId) await ctx.delete(`${API}/doing/plans/${planId}`, { headers: { Authorization: "Bearer " + jwt } });
+    await ctx.dispose();
+  });
+
+  test("assigned volunteer name shows next to the order-of-service item", async ({ page }) => {
+    await page.goto(`/mobile/plans/${planId}`);
+    await expect(page.getByText("Issue988 Sermon")).toBeVisible({ timeout: 30000 });
+    await expect(page.locator(".planItemPosition")).toHaveText(PERSON_NAME, { timeout: 15000 });
+  });
+});


### PR DESCRIPTION
The member-facing plan view now resolves each order-of-service item's `positionId` to the scheduled volunteer's name and shows it beside the item, respecting the plan's `showVolunteerNames` toggle. Depends on ChurchApps/Api#92 for the column and carries a temporary `PlanItemInterface`/`PlanInterface` augmentation in src/types/churchapps-helpers.d.ts that can be dropped once ChurchApps/Packages#24 is published. Sibling UI PR: ChurchApps/B1Admin#462.

Fixes ChurchApps/ChurchAppsSupport#988