### PR TITLE
Let Yarn enforce the lockfile on CI installs

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,9 @@
 nodeLinker: node-modules
 enableScripts: false
-enableImmutableInstalls: false   # local migration installs need to write the lockfile; CI uses --immutable
+# enableImmutableInstalls is deliberately unset: Yarn defaults it to false locally
+# (so dependency changes can write the lockfile) and true under CI. Forcing it to
+# false let Vercel resolve fresh versions instead of yarn.lock, so production ran
+# dependencies that were never built or tested here.
 
 # Git dependencies must be explicitly approved. Empty = none (this project has no git deps).
 # Set explicitly (do NOT just omit it) — Yarn back-fills "**" (trust all) if this key is absent.

--- a/tests/issue-1001.spec.ts
+++ b/tests/issue-1001.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test";
+
+// Issue #1001: tenant pages streamed a full-looking document but the response was
+// HTTP 500 - the RSC pass succeeded while the HTML render threw, so Next served its
+// error shell (<html id="__next_error__">) and the browser re-rendered the real page
+// from the inlined flight data. Assert both halves: the status code and the shell.
+test.describe("Issue 1001 - tenant pages return 200, not an error shell", () => {
+  for (const path of ["/", "/about"]) {
+    test(`${path} renders without Next's error shell`, async ({ page }) => {
+      const response = await page.goto(path);
+      expect(response?.status()).toBe(200);
+      await expect(page.locator("html")).not.toHaveAttribute("id", "__next_error__");
+    });
+  }
+});


### PR DESCRIPTION
Production is running Next 16.3.1 / React 19.2.8 / @sentry/nextjs 10.70.0 even though yarn.lock pins 16.2.6 / 19.2.6 / 10.53.1 — `enableImmutableInstalls: false` in .yarnrc.yml overrode Yarn's CI default, so the Vercel build resolves fresh versions instead of the lockfile and ships dependencies we never built or tested. Dropping that line restores lockfile-pinned CI installs (local installs are unaffected, Yarn only defaults to immutable when CI is set); the added spec is a tripwire asserting tenant pages return 200 and not Next's `__next_error__` shell.

Refs ChurchApps/ChurchAppsSupport#1001