### PR TITLE
Crash :- Add Event → Full Markdown Previewer

### DIFF
--- a/src/app/[sdSlug]/mobile/components/group/CreateEventModal.tsx
+++ b/src/app/[sdSlug]/mobile/components/group/CreateEventModal.tsx
@@ -96,6 +96,14 @@ export const CreateEventModal = ({ open, groupId, initialDateIso, event: eventPr
 
   const [title, setTitle] = React.useState("");
   const [description, setDescription] = React.useState("");
+  const descriptionRef = React.useRef("");
+  const markdownEditorStyle = React.useMemo(
+      () => ({
+        maxHeight: 200,
+        overflowY: "scroll" as const,
+      }),
+      []
+  );
   const [start, setStart] = React.useState("");
   const [end, setEnd] = React.useState("");
   const [allDay, setAllDay] = React.useState(false);
@@ -118,7 +126,8 @@ export const CreateEventModal = ({ open, groupId, initialDateIso, event: eventPr
     if (open) {
       const d = computeDefaults();
       setTitle(d.title);
-      setDescription(d.description);
+      descriptionRef.current = d.description || "";
+      setDescription(d.description || "");
       setStart(d.start);
       setEnd(d.end);
       setAllDay(d.allDay);
@@ -177,7 +186,7 @@ export const CreateEventModal = ({ open, groupId, initialDateIso, event: eventPr
       ...(eventProp || {}),
       groupId: eventProp?.groupId || groupId,
       title: title.trim(),
-      description: description.trim() || undefined,
+      description: descriptionRef.current.trim() || undefined,
       start: localToIsoString(allDay ? `${start.slice(0, 10)}T00:00` : start) as unknown as Date,
       end: localToIsoString(allDay ? `${end.slice(0, 10)}T23:59` : end) as unknown as Date,
       allDay,
@@ -403,9 +412,11 @@ export const CreateEventModal = ({ open, groupId, initialDateIso, event: eventPr
             autoFocus
           />
           <MarkdownEditor
-            value={description}
-            onChange={(val) => setDescription(val)}
-            style={{ maxHeight: 200, overflowY: "scroll" }}
+              value={description}
+              onChange={React.useCallback((val: string) => {
+                descriptionRef.current = val;
+              }, [])}
+              style={markdownEditorStyle}
           />
           <FormControlLabel
             control={<Switch checked={allDay} onChange={(e) => setAllDay(e.target.checked)} />}


### PR DESCRIPTION
Facing a production crash in the **Add Event → Full Markdown Previewer** flow.
https://testmarch03.b1.church/mobile/groups/sAc4gCK3LxQ

This issue was related to both the **package side and B1App side**, and the required fixes have now been implemented on both sides to resolve the crash.

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/4158ed59-357c-4288-8919-69fe427bff9a" />
<img width="666" height="118" alt="image" src="https://github.com/user-attachments/assets/3559d16a-12ee-4e2a-b747-54ffd5aebec5" />
