### PR TITLE
Bump @churchapps/helpers to 2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@churchapps/apphelper": "^1.1.4",
     "@churchapps/content-providers": "^0.8.0",
-    "@churchapps/helpers": "^2.1.0",
+    "@churchapps/helpers": "^2.1.3",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -262,9 +262,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@churchapps/helpers@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@churchapps/helpers@npm:2.1.0"
+"@churchapps/helpers@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@churchapps/helpers@npm:2.1.3"
   dependencies:
     dayjs: "npm:^1.11.20"
   peerDependencies:
@@ -272,7 +272,7 @@ __metadata:
   peerDependenciesMeta:
     rrule:
       optional: true
-  checksum: 10c0/6908d13cc7f191c7b8842f96c2a1eb92487888ab9bfa6d72a463f0a58d44d4f08033a8b9d3d60cfda0880b652eb192bfa7bc988ba60e6e66ef5bda18ca8c5fab
+  checksum: 10c0/60f56ad94130dbc47b188daf697c147249cfa2558aa1dcc6c3d285d783027231d0ea7857cae5a781eb771c332650888e6a47f059f2e0fce622f559a1a6f742a6
   languageName: node
   linkType: hard
 
@@ -4170,7 +4170,7 @@ __metadata:
   dependencies:
     "@churchapps/apphelper": "npm:^1.1.4"
     "@churchapps/content-providers": "npm:^0.8.0"
-    "@churchapps/helpers": "npm:^2.1.0"
+    "@churchapps/helpers": "npm:^2.1.3"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.1"
     "@mui/icons-material": "npm:^7.3.11"


### PR DESCRIPTION
Lockfile was pinned at 2.1.0. Helpers 2.1.3 merges S3 presigned Content-Type/acl instead of posting duplicates, which is the likely Files/blog upload failure on prod.

https://github.com/ChurchApps/ChurchAppsSupport/issues/1021