### PR TITLE
Bump @churchapps/apphelper to 1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "postinstall": "copyfiles -a -f node_modules/@churchapps/apphelper/dist/public/locales/** public/apphelper/locales && copyfiles -a -f node_modules/@churchapps/apphelper/dist/markdown/components/htmlEditor/editor.css public/apphelper/css && copyfiles -a -f node_modules/react-cropper/node_modules/cropperjs/dist/cropper.css public/css && copyfiles -a -f node_modules/@churchapps/apphelper/dist/website/styles/animations.css node_modules/@churchapps/apphelper/dist/website/styles/pages.css src/styles/vendor && copyfiles -a -f node_modules/@churchapps/apphelper/dist/markdown/components/markdownEditor/editor.css public/apphelper/css/markdown && copyfiles -a -u 8 \"node_modules/@churchapps/apphelper/dist/markdown/components/markdownEditor/images/**/*\" public/apphelper/css/markdown/images"
   },
   "dependencies": {
-    "@churchapps/apphelper": "^1.1.4",
+    "@churchapps/apphelper": "^1.1.6",
     "@churchapps/content-providers": "^0.8.0",
     "@churchapps/helpers": "^2.1.3",
     "@emotion/react": "^11.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,9 +187,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@churchapps/apphelper@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@churchapps/apphelper@npm:1.1.4"
+"@churchapps/apphelper@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "@churchapps/apphelper@npm:1.1.6"
   dependencies:
     "@emotion/cache": "npm:^11.14.0"
     "@emotion/react": "npm:^11.14.0"
@@ -251,7 +251,7 @@ __metadata:
       optional: true
     react-google-recaptcha:
       optional: true
-  checksum: 10c0/f406c683fd2b545000d72701090c872047eb8564cd153e3bf6e5247a2abfd2213e209b43197ec12dcf6f31baa67e58e132e0524f4685ba79616db20b4234fe1b
+  checksum: 10c0/62f75b1d1c2db1eab899b94fd0c132f78d59ef97175e08ab4022cf7e6f177a6c027c1d17452734916f6d08cceb994cbb5853025b5b20c26f259a5b85e0562c8b
   languageName: node
   linkType: hard
 
@@ -4168,7 +4168,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "b1-app@workspace:."
   dependencies:
-    "@churchapps/apphelper": "npm:^1.1.4"
+    "@churchapps/apphelper": "npm:^1.1.6"
     "@churchapps/content-providers": "npm:^0.8.0"
     "@churchapps/helpers": "npm:^2.1.3"
     "@emotion/react": "npm:^11.14.0"


### PR DESCRIPTION
Picks up dark-mode colors for notes and message reply.

https://github.com/ChurchApps/ChurchAppsSupport/issues/1016