### PR TITLE
Mobile plan view: render actions nested under a section

### DIFF
--- a/src/app/[sdSlug]/mobile/components/plans/PlanItem.tsx
+++ b/src/app/[sdSlug]/mobile/components/plans/PlanItem.tsx
@@ -70,7 +70,7 @@ export const PlanItem = (props: Props) => {
       <span style={{ float: "right", display: "flex", alignItems: "center", gap: 4 }}>
         <Icon style={{ fontSize: 16, color: "#999" }}>schedule</Icon>
         <span style={{ color: "#666", fontSize: "0.9em", minWidth: 40, textAlign: "right" }}>
-          {PlanHelper.formatTime(pi.seconds || 0)}
+          {PlanHelper.formatTime(pi.children?.length ? PlanHelper.getSectionDuration(pi) : pi.seconds || 0)}
         </span>
       </span>
       <div>{PlanHelper.formatTime(props.startTime || 0)}</div>
@@ -118,9 +118,11 @@ export const PlanItem = (props: Props) => {
       case "providerSection":
       case "lessonSection":
       case "section":
-        return getItemRow(
-          (pi.relatedId || hasProviderFields) ? () => setLessonSectionId(pi.relatedId || pi.providerContentPath || pi.id || null) : undefined
-        );
+        // A section expanded into actions in B1Admin is a folder: show its nested actions beneath it.
+        return <>
+          {getItemRow((pi.relatedId || hasProviderFields) ? () => setLessonSectionId(pi.relatedId || pi.providerContentPath || pi.id || null) : undefined)}
+          {pi.children?.length ? <div style={{ paddingLeft: 16 }}>{getChildren()}</div> : null}
+        </>;
       case "item":
       default:
         // Audio links open the inline player dialog instead of downloading via the OS (issue #960)


### PR DESCRIPTION
B1Admin can now nest expanded actions under their section (#1009). The mobile service order renders those children under the section row and shows the section's time as the sum of its children.