### PR TITLE
Allow Maps in CSP and stop rendering raw script tags

### DIFF
--- a/src/app/[sdSlug]/mobile/components/details/GroupDetail.tsx
+++ b/src/app/[sdSlug]/mobile/components/details/GroupDetail.tsx
@@ -659,7 +659,7 @@ const AuthenticatedGroupDetail = ({ idOrSlug, config }: { idOrSlug: string; conf
             }}
           >
             <Tabs
-              value={tab}
+              value={availableTabs.some((t) => t.key === tab) ? tab : defaultTab}
               onChange={(_, v) => {
                 if (v === "messages") {
                   setChatInitialTab("discussions");

--- a/src/app/[sdSlug]/mobile/layout.tsx
+++ b/src/app/[sdSlug]/mobile/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata, Viewport } from "next";
 import { Newsreader } from "next/font/google";
 import { ConfigHelper, EnvironmentHelper } from "@/helpers";
 import { isValidHex, shade, tint } from "@/helpers/colorTints";
+import Script from "next/script";
 import { PwaRegister } from "./PwaRegister";
 import { MobileClientLayout } from "./MobileClientLayout";
 import { MobileKeepAlive } from "./components/MobileKeepAlive";
@@ -57,7 +58,9 @@ export default async function MobileLayout({ children, params }: { children: Rea
       <meta name="apple-mobile-web-app-title" content={appTitle} />
       <link rel="preconnect" href="https://content.churchapps.org" />
       <link rel="preconnect" href="https://content.lessons.church" />
-      <script
+      <Script
+        id="b1-install-prompt"
+        strategy="afterInteractive"
         dangerouslySetInnerHTML={{ __html: `(function(){if(typeof window==="undefined")return;var state=window.__b1InstallPromptState=window.__b1InstallPromptState||{deferredPrompt:null,installed:false};var detect=function(){try{return !!((window.matchMedia&&window.matchMedia("(display-mode: standalone)").matches)||(window.navigator&&window.navigator.standalone===true));}catch(_e){return false;}};state.installed=detect();window.addEventListener("beforeinstallprompt",function(e){e.preventDefault();state.deferredPrompt=e;state.installed=false;});window.addEventListener("appinstalled",function(){state.installed=true;state.deferredPrompt=null;});window.addEventListener("pageshow",function(){state.installed=detect();if(state.installed)state.deferredPrompt=null;});})();` }}
       />
       <div className={serifFont.variable}>

--- a/src/components/seo/BlogPostingJsonLd.tsx
+++ b/src/components/seo/BlogPostingJsonLd.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Script from "next/script";
 import { ConfigurationInterface } from "@/helpers/ConfigHelper";
 import type { PostInterface } from "@/helpers/interfaces";
 
@@ -30,5 +31,5 @@ export function BlogPostingJsonLd({ config, post, url }: Props) {
   const logo = config.appearance?.logoLight || config.appearance?.logoDark;
   if (logo) (data.publisher as Record<string, unknown>).logo = { "@type": "ImageObject", url: logo };
 
-  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />;
+  return <Script id="blog-jsonld" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />;
 }

--- a/src/components/seo/ChurchJsonLd.tsx
+++ b/src/components/seo/ChurchJsonLd.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Script from "next/script";
 import { ConfigurationInterface } from "@/helpers/ConfigHelper";
 
 interface Props { config: ConfigurationInterface; }
@@ -28,5 +29,5 @@ export function ChurchJsonLd({ config }: Props) {
     };
   }
 
-  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />;
+  return <Script id="church-jsonld" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />;
 }

--- a/src/components/seo/EventJsonLd.tsx
+++ b/src/components/seo/EventJsonLd.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Script from "next/script";
 import { EventHelper } from "@churchapps/helpers";
 import type { EventInterface, ChurchInterface } from "@churchapps/helpers";
 import { fetchCached, type ConfigurationInterface } from "@/helpers/ConfigHelper";
@@ -91,7 +92,7 @@ export async function EventJsonLd({ config, pageData, sdSlug }: Props) {
     });
 
     const payload = data.length === 1 ? data[0] : data;
-    return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(payload) }} />;
+    return <Script id="event-jsonld" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(payload) }} />;
   } catch {
     return null;
   }

--- a/src/components/seo/SermonJsonLd.tsx
+++ b/src/components/seo/SermonJsonLd.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Script from "next/script";
 import type { ChurchInterface, SermonInterface } from "@churchapps/helpers";
 import { getSermonEmbed } from "@/helpers/sermonEmbed";
 
@@ -25,5 +26,5 @@ export function SermonJsonLd({ church, sermon }: Props) {
   if (typeof sermon.duration === "number" && sermon.duration > 0) video.duration = "PT" + Math.round(sermon.duration) + "S";
 
   if (!video.embedUrl && !video.contentUrl && !video.thumbnailUrl) return null;
-  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(video) }} />;
+  return <Script id="sermon-jsonld" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(video) }} />;
 }

--- a/src/components/seo/SermonVideoJsonLd.tsx
+++ b/src/components/seo/SermonVideoJsonLd.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Script from "next/script";
 import type { SermonInterface } from "@churchapps/helpers";
 import { fetchCached, type ConfigurationInterface } from "@/helpers/ConfigHelper";
 import type { PageInterface } from "@/helpers/interfaces";
@@ -58,7 +59,7 @@ export async function SermonVideoJsonLd({ config, pageData, sdSlug, sermonsPage 
 
     if (data.length === 0) return null;
     const payload = data.length === 1 ? data[0] : data;
-    return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(payload) }} />;
+    return <Script id="sermon-video-jsonld" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(payload) }} />;
   } catch {
     return null;
   }

--- a/src/helpers/contentSecurityPolicy.ts
+++ b/src/helpers/contentSecurityPolicy.ts
@@ -54,6 +54,10 @@ export const CONNECT_SRC_HOSTS = [
   "https://*.youversion.com",
   "https://www.google.com",
   "https://www.gstatic.com",
+  "https://maps.googleapis.com",
+  "https://maps.gstatic.com",
+  "https://*.googleapis.com",
+  "https://*.gstatic.com",
   "wss://*.churchapps.org",
   "wss://*.b1.church",
   NMI_HOST

--- a/tests/unit/contentSecurityPolicy.test.ts
+++ b/tests/unit/contentSecurityPolicy.test.ts
@@ -60,6 +60,12 @@ describe("buildContentSecurityPolicy", () => {
     }
   });
 
+  it("allows Google Maps geocode and JS hosts on connect-src", () => {
+    const connectSrc = directive(buildContentSecurityPolicy({ nonce: "n" }), "connect-src");
+    assert.ok(connectSrc.includes("https://maps.googleapis.com"));
+    assert.ok(connectSrc.includes("https://maps.gstatic.com"));
+  });
+
   it("keeps style-src inline (React style attributes) and matches the CSS @import allowlist", () => {
     const styleSrc = directive(buildContentSecurityPolicy({ nonce: "n" }), "style-src");
     assert.ok(styleSrc.includes("'unsafe-inline'"));


### PR DESCRIPTION
Geocode calls were blocked by connect-src, and raw script tags in the mobile layout and JSON-LD caused React warnings plus CSP script-src violations. Allow Google Maps hosts and use next/script.