### PR TITLE
Playwright hosts from env for demo slots

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,10 @@ const STORAGE_STATE_PATH = path.join(__dirname, "tests", ".auth-state.json");
 
 // Windows doesn't resolve *.localhost; use localtest.me instead
 const baseURL = process.env.BASE_URL || "http://grace.localtest.me:3301";
+const appPort = new URL(baseURL).port || "3301";
+const apiBase = process.env.API_BASE || "http://localhost:8084";
+const lessonsApiBase = process.env.LESSONS_API_BASE || "http://localhost:8090";
+const messagingSocket = process.env.NEXT_PUBLIC_MESSAGING_API_SOCKET || "ws://localhost:8087";
 
 export default defineConfig({
   testDir: "./tests",
@@ -37,7 +41,7 @@ export default defineConfig({
   webServer: [
     {
       command: "npm --prefix ../Api run dev",
-      url: "http://localhost:8084/health",
+      url: `${apiBase}/health`,
       reuseExistingServer: true,
       timeout: 60 * 1000,
       stdout: "pipe",
@@ -45,7 +49,7 @@ export default defineConfig({
     },
     {
       command: "npm --prefix ../LessonsApi run dev",
-      url: "http://localhost:8090/health",
+      url: `${lessonsApiBase}/health`,
       reuseExistingServer: true,
       timeout: 90 * 1000,
       stdout: "pipe",
@@ -53,14 +57,15 @@ export default defineConfig({
     },
     {
       // Force dev so EnvironmentHelper uses localhost API URLs from .env
-      command: "npm run dev",
+      command: `npm run dev -- -p ${appPort}`,
       env: {
         NEXT_PUBLIC_STAGE: "dev",
-        NEXT_PUBLIC_LESSONS_API: "http://localhost:8090",
+        NEXT_PUBLIC_API_BASE: apiBase,
+        NEXT_PUBLIC_LESSONS_API: lessonsApiBase,
         // Localhost socket for consolidated subscription stack and cross-user realtime tests
-        NEXT_PUBLIC_MESSAGING_API_SOCKET: "ws://localhost:8087"
+        NEXT_PUBLIC_MESSAGING_API_SOCKET: messagingSocket
       },
-      url: "http://localhost:3301",
+      url: `http://localhost:${appPort}`,
       reuseExistingServer: true,
       timeout: 120 * 1000
     }

--- a/tests/api-messaging-authz.spec.ts
+++ b/tests/api-messaging-authz.spec.ts
@@ -5,7 +5,7 @@ import { test, expect, request, type APIRequestContext } from "@playwright/test"
  * No browser UI - every case is a raw HTTP status assertion against the local demo stack.
  */
 
-const MESSAGING = "http://localhost:8084/messaging";
+const MESSAGING = (process.env.API_BASE || "http://localhost:8084") + "/messaging";
 const CHURCH_ID = "CHU00000001";
 const OTHER_GROUP = "GRP00000016"; // Men's Bible Study - volunteer is not a member
 const OWN_GROUP = "GRP00000025"; // Greeters Ministry - volunteer is a member
@@ -15,7 +15,7 @@ type Identity = { ctx: APIRequestContext; jwt: string };
 
 async function login(email: string): Promise<Identity> {
   const ctx = await request.newContext();
-  const res = await ctx.post("http://localhost:8084/membership/users/login", {
+  const res = await ctx.post((process.env.API_BASE || "http://localhost:8084") + "/membership/users/login", {
     data: { email, password: "password" },
     headers: { "Content-Type": "application/json" }
   });
@@ -98,7 +98,7 @@ test.describe("Messaging API authorization", () => {
 test.describe("Group chat feed toggles (API)", () => {
   test.describe.configure({ mode: "serial" });
 
-  const MEMBERSHIP = "http://localhost:8084/membership";
+  const MEMBERSHIP = (process.env.API_BASE || "http://localhost:8084") + "/membership";
   let volunteer: Identity;
   let demo: Identity;
   let demoMembership: Identity;

--- a/tests/helpers/api.ts
+++ b/tests/helpers/api.ts
@@ -1,7 +1,7 @@
 import { APIRequestContext, request } from "@playwright/test";
 
-const MAIN_API = "http://localhost:8084";
-const LESSONS_API = "http://localhost:8090";
+const MAIN_API = process.env.API_BASE || "http://localhost:8084";
+const LESSONS_API = process.env.LESSONS_API_BASE || "http://localhost:8090";
 
 export type ApiHandle = {
   request: APIRequestContext;

--- a/tests/issue-1000.spec.ts
+++ b/tests/issue-1000.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, request, type Page } from "@playwright/test";
 
-const MAIN_API = "http://localhost:8084";
+const MAIN_API = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 // volunteer@b1.church (Rachel Martin) is a plain member of GRP00000025 and the leader of GRP00000029
 const MEMBER_GROUP = "GRP00000025";

--- a/tests/issue-988.spec.ts
+++ b/tests/issue-988.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 
 // Issue #988: the member-facing plan view shows the volunteer assigned to each
 // order-of-service item, gated by the plan's showVolunteerNames toggle.
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 const PERSON_ID = "PER00000001";
 const PERSON_NAME = "John Smith";
 

--- a/tests/issue-999.spec.ts
+++ b/tests/issue-999.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, request, type APIRequestContext, type BrowserContext, type Page } from "@playwright/test";
 
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 // Rachel Martin (volunteer@b1.church) leads GRP00000029 and is a plain member of GRP00000025.
 const LED_GROUP = "GRP00000029";

--- a/tests/mobile-campaigns.spec.ts
+++ b/tests/mobile-campaigns.spec.ts
@@ -14,11 +14,11 @@ async function gotoOverview(page: import("@playwright/test").Page) {
 
 test.describe.serial("Mobile donate — CampaignProgress", () => {
   test.beforeAll(async ({ request }) => {
-    const loginRes = await request.post("http://localhost:8084/membership/users/login", { data: { email: "demo@b1.church", password: "password" } });
+    const loginRes = await request.post((process.env.API_BASE || "http://localhost:8084") + "/membership/users/login", { data: { email: "demo@b1.church", password: "password" } });
     const loginBody = await loginRes.json();
     jwt = loginBody.userChurches[0].jwt;
 
-    const campaignRes = await request.post("http://localhost:8084/giving/campaigns", {
+    const campaignRes = await request.post((process.env.API_BASE || "http://localhost:8084") + "/giving/campaigns", {
       headers: { Authorization: "Bearer " + jwt },
       data: [{ name: "PW Test Campaign", goalAmount: 10000, startDate: "2026-01-01", endDate: "2026-12-31", showPublic: true, allowSelfPledge: true }]
     });
@@ -27,7 +27,7 @@ test.describe.serial("Mobile donate — CampaignProgress", () => {
   });
 
   test.afterAll(async ({ request }) => {
-    const pledgesRes = await request.get("http://localhost:8084/giving/pledges/my", { headers: { Authorization: "Bearer " + jwt } });
+    const pledgesRes = await request.get((process.env.API_BASE || "http://localhost:8084") + "/giving/pledges/my", { headers: { Authorization: "Bearer " + jwt } });
     if (pledgesRes.ok()) {
       const pledges = await pledgesRes.json();
       if (Array.isArray(pledges)) {
@@ -35,13 +35,13 @@ test.describe.serial("Mobile donate — CampaignProgress", () => {
           if (p.pledge?.campaignId === campaignId || p.campaignId === campaignId) {
             const pledgeId = p.pledge?.id || p.id;
             if (pledgeId) {
-              await request.delete("http://localhost:8084/giving/pledges/my/" + pledgeId, { headers: { Authorization: "Bearer " + jwt } });
+              await request.delete((process.env.API_BASE || "http://localhost:8084") + "/giving/pledges/my/" + pledgeId, { headers: { Authorization: "Bearer " + jwt } });
             }
           }
         }
       }
     }
-    await request.delete("http://localhost:8084/giving/campaigns/" + campaignId, { headers: { Authorization: "Bearer " + jwt } });
+    await request.delete((process.env.API_BASE || "http://localhost:8084") + "/giving/campaigns/" + campaignId, { headers: { Authorization: "Bearer " + jwt } });
   });
 
   test("donate page shows the campaign with progress", async ({ page }) => {

--- a/tests/mobile-community.spec.ts
+++ b/tests/mobile-community.spec.ts
@@ -7,7 +7,7 @@ test.describe.configure({ mode: "serial" });
 
 async function setDirectoryVisibility(value: string) {
   const ctx = await request.newContext();
-  const login = await ctx.post("http://localhost:8084/membership/users/login", {
+  const login = await ctx.post((process.env.API_BASE || "http://localhost:8084") + "/membership/users/login", {
     data: { email: "demo@b1.church", password: "password" },
     headers: { "Content-Type": "application/json" }
   });
@@ -17,11 +17,11 @@ async function setDirectoryVisibility(value: string) {
   const jwt = uc?.apis?.find((a: any) => a.keyName === "MembershipApi")?.jwt;
   if (!jwt) throw new Error("MembershipApi JWT not present");
   const headers = { Authorization: `Bearer ${jwt}`, "Content-Type": "application/json" };
-  const settings = await (await ctx.get("http://localhost:8084/membership/settings", { headers })).json();
+  const settings = await (await ctx.get((process.env.API_BASE || "http://localhost:8084") + "/membership/settings", { headers })).json();
   const setting = (settings || []).find((x: any) => x.keyName === "directoryVisibility")
     || { churchId: DEMO_CHURCH.ID, public: 1, keyName: "directoryVisibility" };
   setting.value = value;
-  const res = await ctx.post("http://localhost:8084/membership/settings", { headers, data: [setting] });
+  const res = await ctx.post((process.env.API_BASE || "http://localhost:8084") + "/membership/settings", { headers, data: [setting] });
   if (!res.ok()) throw new Error(`settings save failed: ${res.status()}`);
   await ctx.dispose();
 }

--- a/tests/mobile-donate-kf.spec.ts
+++ b/tests/mobile-donate-kf.spec.ts
@@ -67,10 +67,10 @@ async function deleteAllCards(page: Page) {
 // Browser-side delete can report "Failed to fetch" while the Api is still detaching at NMI; clean up server-side instead.
 async function deleteAllCardsViaApi() {
   const api = await getApi("demo");
-  const res = await apiCall(api, "get", "http://localhost:8084/giving/paymentmethods/personid/PER00000082");
+  const res = await apiCall(api, "get", (process.env.API_BASE || "http://localhost:8084") + "/giving/paymentmethods/personid/PER00000082");
   const pms: any[] = await res.json();
   for (const pm of pms) {
-    const del = await apiCall(api, "delete", `http://localhost:8084/giving/paymentmethods/${pm.id}/${pm.customerId}?provider=${pm.provider}`);
+    const del = await apiCall(api, "delete", `${process.env.API_BASE || "http://localhost:8084"}/giving/paymentmethods/${pm.id}/${pm.customerId}?provider=${pm.provider}`);
     expect(del.ok(), `delete ${pm.id}: ${del.status()}`).toBe(true);
   }
 }
@@ -144,7 +144,7 @@ test.describe.serial("Kingdom Funding member donations (live NMI test gateway)",
     }).toPass({ timeout: 60000 }).catch(() => { console.log("DIAG:\n" + diag.join("\n")); throw new Error("recurring gift not listed on History tab"); });
 
     const api = await getApi("demo");
-    const del = await apiCall(api, "delete", `http://localhost:8084/giving/subscriptions/${subId}`);
+    const del = await apiCall(api, "delete", `${process.env.API_BASE || "http://localhost:8084"}/giving/subscriptions/${subId}`);
     expect(del.ok(), `cancel subscription ${subId}: ${del.status()}`).toBe(true);
   });
 

--- a/tests/mobile-donate-paystack.spec.ts
+++ b/tests/mobile-donate-paystack.spec.ts
@@ -6,8 +6,8 @@ import crypto from "crypto";
 // Test instruments: mobile money 0551234987/MTN (no OTP); card = Paystack's built-in "Success" test card.
 test.describe.configure({ mode: "serial" });
 
-const API = "http://localhost:8084";
-const BASE_URL = "http://accra.localtest.me:3301";
+const API = process.env.API_BASE || "http://localhost:8084";
+const BASE_URL = (process.env.BASE_URL || "http://grace.localtest.me:3301").replace("grace.", "accra.");
 const CHURCH_ID = "CHU00000002";
 const PERSON_ID = "PER00000098";
 // Same test secret that giving/demo.sql seeds (encrypted) for GAT00000002 — needed to sign webhook payloads.

--- a/tests/mobile-donate.spec.ts
+++ b/tests/mobile-donate.spec.ts
@@ -55,7 +55,7 @@ test.describe("Mobile donate", () => {
 // Country receipt formats: the donor-facing statement mirrors the B1Admin legal block,
 // driven by the church's statement-format settings.
 test.describe.serial("Mobile donate statement receipt formats", () => {
-  const MAIN_API = "http://localhost:8084";
+  const MAIN_API = process.env.API_BASE || "http://localhost:8084";
   const REG_NUMBER = "119288945RR0001";
 
   // /membership/settings inserts a new row when no id is sent, so reuse existing ids

--- a/tests/mobile-events.spec.ts
+++ b/tests/mobile-events.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, request } from "@playwright/test";
 import { mobileLogoutButton } from "./helpers/mobile";
 
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 
 test.describe("Mobile event registration", () => {

--- a/tests/mobile-first-day.spec.ts
+++ b/tests/mobile-first-day.spec.ts
@@ -4,7 +4,7 @@ import { mobileLogoutButton } from "./helpers/mobile";
 // ChurchAppsSupport #985: church.firstDayOfWeek (0=Sun..6=Sat) drives the group
 // calendar week grid. Mutates the seeded church's setting, so runs serially and
 // restores the original value when done.
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 const GROUP_ID = "GRP00000004";
 const SUBDOMAIN = "grace";

--- a/tests/mobile-group-take-home.spec.ts
+++ b/tests/mobile-group-take-home.spec.ts
@@ -29,7 +29,7 @@ async function seedTakeHome(unique: string) {
     const planRes = await apiCall(demo, "post", doingUrl("/plans"), [{ ministryId: "GRP0000000a", planTypeId: "PLT00000001", name: `Take-home ${unique}`, serviceDate: daysAgoYmd(1), notes: "", serviceOrder: true, providerId: "lessonschurch", providerPlanId: PROVIDER_PATH, providerPlanName: unique, contentType: "provider", contentId: "VEN00000002" }]);
     const body = await planRes.text();
     expect(planRes.status(), `plan POST: ${body.slice(0, 300)}`).toBe(200);
-    const listed = await apiCall(demo, "get", "http://localhost:8084/membership/groups/GRP00000004/plans");
+    const listed = await apiCall(demo, "get", (process.env.API_BASE || "http://localhost:8084") + "/membership/groups/GRP00000004/plans");
     const plans = await listed.json();
     expect(Array.isArray(plans) && plans.some((p: any) => p.providerPlanId === PROVIDER_PATH), `group plans: ${JSON.stringify(plans).slice(0, 400)}`).toBeTruthy();
   } finally {
@@ -44,7 +44,7 @@ test.describe("Group take-home card", () => {
 
     await page.route(/\/lessons\/public\/ids/, async (route) => {
       const ids = new URL(route.request().url()).searchParams.get("ids") || "";
-      const res = await page.request.get(`http://localhost:8090/lessons/public/ids?ids=${ids}`);
+      const res = await page.request.get(`${process.env.LESSONS_API_BASE || "http://localhost:8090"}/lessons/public/ids?ids=${ids}`);
       await route.fulfill({ status: res.status(), contentType: "application/json", body: await res.text() });
     });
 

--- a/tests/mobile-groups-join.spec.ts
+++ b/tests/mobile-groups-join.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, request, type Page, type APIRequestContext } from "@playwright/test";
 
-const MAIN_API = "http://localhost:8084";
+const MAIN_API = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 // volunteer@b1.church (Rachel Martin) leads GRP00000029 (Financial Peace); demo@b1.church (Demo User) is not a member of it.
 const LEADER_GROUP_ID = "GRP00000029";

--- a/tests/mobile-groups.spec.ts
+++ b/tests/mobile-groups.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, request, type APIRequestContext } from "@playwright/test";
 import { mobileLogoutButton } from "./helpers/mobile";
 
-const MAIN_API = "http://localhost:8084";
+const MAIN_API = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 
 async function membershipHeaders(ctx: APIRequestContext) {

--- a/tests/mobile-registration-commerce.spec.ts
+++ b/tests/mobile-registration-commerce.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, type Page } from "@playwright/test";
 // Serial: tests share demo@b1.church's registrations + Stripe customer.
 test.describe.configure({ mode: "serial" });
 
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 const CHURCH = "CHU00000001";
 const GROUP = "GRP00000030";
 const VBS = "EVT00000015";

--- a/tests/mobile-request-event.spec.ts
+++ b/tests/mobile-request-event.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, request, type Page } from "@playwright/test";
 import { mobileLogoutButton } from "./helpers/mobile";
 
 // CA-1: Sanctuary/Fellowship Hall (auto-approved), Youth Room (approval-gated, demo pending)
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 
 async function demoJwt(): Promise<string> {

--- a/tests/mobile-rsvp.spec.ts
+++ b/tests/mobile-rsvp.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, request, type Page } from "@playwright/test";
 import { mobileLogoutButton } from "./helpers/mobile";
 
 // GR-1: EVT00000018 (Midweek Small Group) weekly recurring on GRP00000004 (demo + tester members)
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 const GROUP_ID = "GRP00000004";
 const EVENT_ID = "EVT00000018";

--- a/tests/public-navigation.spec.ts
+++ b/tests/public-navigation.spec.ts
@@ -48,7 +48,7 @@ test.describe("Public navigation", () => {
   });
 
   test("navStyles override applies to live nav rendering", async ({ page, request }) => {
-    const API_BASE = "http://localhost:8084";
+    const API_BASE = process.env.API_BASE || "http://localhost:8084";
     const loginRes = await request.post(`${API_BASE}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });
     const loginBody = await loginRes.json();
     const grace = loginBody.userChurches.find((uc: any) => uc.church.id === "CHU00000001");
@@ -87,7 +87,7 @@ test.describe("Public navigation", () => {
   });
 
   test("footer falls back to logo, address, and nav links when no footer block is configured", async ({ page, request }) => {
-    const API_BASE = "http://localhost:8084";
+    const API_BASE = process.env.API_BASE || "http://localhost:8084";
     const loginRes = await request.post(`${API_BASE}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });
     const loginBody = await loginRes.json();
     const grace = loginBody.userChurches.find((uc: any) => uc.church.id === DEMO_CHURCH.ID);

--- a/tests/realtime-cross-user-pm.spec.ts
+++ b/tests/realtime-cross-user-pm.spec.ts
@@ -5,7 +5,7 @@ import { waitForAlertsJoin } from "./helpers/realtime";
 
 const DEMO_PERSON_ID = "PER00000082";
 const TESTER_PERSON_ID = "PER00000083";
-const MAIN_API = "http://localhost:8084";
+const MAIN_API = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 
 async function messagingApi(email: string) {

--- a/tests/realtime-private-messages.spec.ts
+++ b/tests/realtime-private-messages.spec.ts
@@ -22,7 +22,7 @@ test.describe("Realtime — private messages", () => {
   });
 });
 
-const MAIN_API = "http://localhost:8084";
+const MAIN_API = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 const TESTER_PERSON_ID = "PER00000083";
 const DEMO_PERSON_ID = "PER00000082";

--- a/tests/realtime-stream-chat.spec.ts
+++ b/tests/realtime-stream-chat.spec.ts
@@ -134,7 +134,7 @@ test.describe("Live stream chat — cross-user realtime", () => {
   });
 });
 
-const MESSAGING_API = "http://localhost:8084/messaging";
+const MESSAGING_API = (process.env.API_BASE || "http://localhost:8084") + "/messaging";
 const CHURCH_ID = "CHU00000001";
 const DEMO_SERVICE_ID = "STR00000002";
 const DEMO_PERSON_ID = "PER00000082";

--- a/tests/registration.spec.ts
+++ b/tests/registration.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, request } from "@playwright/test";
 
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 const GROUP_ID = "GRP00000030"; // VBS group — already used by EVT00000015, known-good churchId scope.
 const NO_FORM_TITLE = "Web Wizard Test Event (No Form)";

--- a/tests/setup/verify-env.mjs
+++ b/tests/setup/verify-env.mjs
@@ -1,5 +1,5 @@
 const DEFAULT_BASE_URL = "http://grace.localtest.me:3301";
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 // Tests work against either ENVIRONMENT=demo (stage demo deployments) or
 // ENVIRONMENT=dev pointed at localhost — same set reset-demo accepts.
 const ALLOWED_ENVIRONMENTS = ["demo", "dev"];

--- a/tests/webpush-api.spec.ts
+++ b/tests/webpush-api.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 /** Contract test for POST /messaging/webpush/subscribe device enrollment (server-side, not browser PushManager). */
 
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 
 async function loginAndGetMessagingJwt() {
   const res = await fetch(`${API_BASE}/membership/users/login`, {


### PR DESCRIPTION
Specs and playwright.config now read BASE_URL, API_BASE and LESSONS_API_BASE (defaults unchanged), so a worktree lane can run its whole stack on shifted ports and its own s<N>_ databases alongside another lane instead of waiting on the single demo lock.